### PR TITLE
add neuron scheduler to vllm deployment

### DIFF
--- a/charts/inference-charts/Chart.yaml
+++ b/charts/inference-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: inference-charts
 description: A Helm chart for AI on EKS
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0.0"

--- a/charts/inference-charts/templates/vllm-deployment.yaml
+++ b/charts/inference-charts/templates/vllm-deployment.yaml
@@ -57,6 +57,7 @@ spec:
           startupProbe:
             {{- toYaml .Values.inference.modelServer.deployment.startupProbe | nindent 12 }}
       {{- if eq .Values.inference.accelerator "neuron" }}
+      schedulerName: my-scheduler
       tolerations:
         - key: "aws.amazon.com/neuron"
           operator: "Exists"


### PR DESCRIPTION
*Issue #, if available:*

Raised in #5 

*Description of changes:*

Adds the missing `schedulerName: my-scheduler` to neuron deployments using`vllm` framework

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
