### PR TITLE
feat: add NVIDIA NIM inference examples for SD 3.5 and Llama 3 8B

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ helm install qwen3-1-7b ai-on-eks/inference-charts \
 
 ### Language Models
 
-- **Llama Series**: 2-13B, 3-70B, 3.1-8B, 3.2-1B, 4-Scout-17B
+- **Llama Series**: 2-13B, 3-70B, 3-8b-instruct, 3.1-8B, 3.2-1B, 4-Scout-17B
 - **DeepSeek**: R1 Distill Llama 8B
 - **Mistral**: Small 24B
 - **Qwen**: 3 Coder 480B, 3-1.7B
@@ -66,6 +66,7 @@ helm install qwen3-1-7b ai-on-eks/inference-charts \
 - **Triton + vLLM**: NVIDIA Triton integration
 - **Diffusers**: Hugging Face diffusion models
 - **LWS (LeaderWorkerSet)**: Kubernetes-native distributed serving
+- **NIM (NVIDIA Inference Microservices)** - NVIDIA GPU optimized inference containers (needs NGC Key)
 
 ## Hardware Support
 

--- a/charts/inference-charts/Chart.yaml
+++ b/charts/inference-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: inference-charts
 description: A Helm chart for AI on EKS
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0.0"

--- a/charts/inference-charts/README.md
+++ b/charts/inference-charts/README.md
@@ -601,6 +601,8 @@ helm install latent-diffusion ./inference-charts --values values-latent-diffusio
 
 ### NVIDIA NIM Examples
 
+> **Note:** To set up a NIM-enabled EKS cluster, use the installation script available at: https://github.com/awslabs/ai-on-eks/tree/main/infra/nvidia-nim
+
 #### Prerequisites for NIM Deployments
 
 Before deploying NIM, create the required secrets:
@@ -682,10 +684,11 @@ Then in your API request:
 }
 ```
 
-**Note**: 
+**Note**:
 - **LLM NIMs** (like Llama) take 10-15 minutes to become ready
 - **Diffusion NIMs** (like Stable Diffusion) take 20-30 minutes to become ready
 - Monitor progress with: `kubectl logs -f deployment/<service-name> -n default`
+- To prevent pod eviction by Karpenter during long startup times, add the annotation `karpenter.sh/do-not-evict: "true"` to `podTemplate.annotations` in your values file
 
 **Comparison: NIM vs Diffusers**
 
@@ -714,7 +717,7 @@ Then in your API request:
 **Additional Resources**
 
 - [NVIDIA NIM Documentation](https://docs.nvidia.com/nim/)
-- [NGC Catalog](https://catalog.ngc.nvidia.com/) 
+- [NGC Catalog](https://catalog.ngc.nvidia.com/)
 - [Stable Diffusion NIM Guide](https://docs.nvidia.com/nim/visual-genai/)
 - [Main README](./README.md)
 

--- a/charts/inference-charts/README.md
+++ b/charts/inference-charts/README.md
@@ -47,7 +47,7 @@ The chart supports the following deployment types:
 - Includes additional model labels for AIBrix integration
 - Suitable for AIBrix-managed inference workloads
 
-**NVIDIA NIM Deployments** (`framework: nim`):
+**NVIDIA NIM Container Deployments** (`framework: nim-container`):
 
 - NVIDIA Inference Microservices for optimized model serving
 - Pre-built, optimized containers from NVIDIA NGC catalog
@@ -129,7 +129,7 @@ The following table lists the configurable parameters of the inference-charts ch
 |--------------------------------------------------------------------------|-------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `global.image.pullPolicy`                                                | Global image pull policy                                                            | `IfNotPresent`                                                              |
 | `inference.accelerator`                                                  | Accelerator type to use (gpu or neuron)                                             | `gpu`                                                                       |
-| `inference.framework`                                                    | Framework type to use (vllm, ray-vllm, triton-vllm, aibrix, lws-vllm,  diffusers, or nim) | `vllm`                                                                      |
+| `inference.framework`                                                    | Framework type to use (vllm, ray-vllm, triton-vllm, aibrix, lws-vllm,  diffusers, or nim-container) | `vllm`                                                                      |
 | `inference.serviceName`                                                  | Name of the inference service                                                       | `inference`                                                                 |
 | `inference.serviceNamespace`                                             | Namespace for the inference service                                                 | `default`                                                                   |
 | `inference.modelServer.image.repository`                                 | Model server image repository                                                       | `vllm/vllm-openai`                                                          |
@@ -667,7 +667,7 @@ helm install latent-diffusion ai-on-eks/inference-charts -f https://raw.githubus
 
 ### NVIDIA NIM Examples
 
-> **Note:** To set up a NIM-enabled EKS cluster, use the installation script available at: https://github.com/awslabs/ai-on-eks/tree/main/infra/nvidia-nim
+> **Note:** To set up an inference EKS cluster, follow instructions at: https://awslabs.github.io/ai-on-eks/docs/infra/inference-ready-cluster
 
 #### Prerequisites for NIM Deployments
 

--- a/charts/inference-charts/README.md
+++ b/charts/inference-charts/README.md
@@ -468,97 +468,145 @@ serviceAccountName: s3-model-copy-sa  # Service account with S3 write permission
 ### Deploy GPU Ray-VLLM with DeepSeek R1 Distill Llama 8B model
 
 ```bash
-helm install deepseek-gpu-inference ./inference-charts --values values-deepseek-r1-distill-llama-8b-ray-vllm-gpu.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install deepseek-gpu-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-deepseek-r1-distill-llama-8b-ray-vllm-gpu.yaml
 ```
 
 ### Deploy GPU VLLM with Llama 3.2 1B model
 
 ```bash
-helm install gpu-vllm-inference ./inference-charts --values values-llama-32-1b-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-vllm-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-32-1b-vllm.yaml
 ```
 
 ### Deploy GPU LeaderWorkerSet-VLLM with Llama 4 Scout 17B model
 
 ```bash
-helm install llama4-lws-inference ./inference-charts --values values-llama-4-scout-17b-lws-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install llama4-lws-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-4-scout-17b-lws-vllm.yaml
 ```
 
 ### Deploy GPU LeaderWorkerSet-VLLM with Qwen3 Coder 480B A35B Instruct model
 
 ```bash
-helm install qwen3-coder-lws-inference ./inference-charts --values values-qwen-3-coder-480b-a35b-instruct-lws-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install qwen3-coder-lws-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-qwen-3-coder-480b-a35b-instruct-lws-vllm.yaml
 ```
 
 ### Deploy GPU Ray-VLLM with Llama 3.2 1B model
 
 ```bash
-helm install gpu-ray-vllm-inference ./inference-charts --values values-llama-32-1b-ray-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-ray-vllm-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-32-1b-ray-vllm.yaml
 ```
 
 ### Deploy GPU AIBrix with Llama 3.2 1B model
 
 ```bash
-helm install gpu-aibrix-inference ./inference-charts --values values-llama-32-1b-aibrix.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-aibrix-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-32-1b-aibrix.yaml
 ```
 
 ### Deploy Neuron VLLM with DeepSeek R1 Distill Llama 8B model
 
 ```bash
-helm install deepseek-neuron-inference ./inference-charts --values values-deepseek-r1-distill-llama-8b-vllm-neuron.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install deepseek-neuron-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-deepseek-r1-distill-llama-8b-vllm-neuron.yaml
 ```
 
 ### Deploy Neuron Ray-VLLM with Llama 2 13B model
 
 ```bash
-helm install llama2-neuron-inference ./inference-charts --values values-llama-2-13b-ray-vllm-neuron.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install llama2-neuron-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-2-13b-ray-vllm-neuron.yaml
 ```
 
 ### Deploy Neuron Ray-VLLM with Llama 3 70B model
 
 ```bash
-helm install llama3-70b-neuron-inference ./inference-charts --values values-llama-3-70b-ray-vllm-neuron.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install llama3-70b-neuron-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-3-70b-ray-vllm-neuron.yaml
 ```
 
 ### Deploy Neuron VLLM with Llama 3.1 8B model
 
 ```bash
-helm install neuron-vllm-inference ./inference-charts --values values-llama-31-8b-vllm-neuron.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install neuron-vllm-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-31-8b-vllm-neuron.yaml
 ```
 
 ### Deploy Neuron Ray-VLLM with Llama 3.1 8B model
 
 ```bash
-helm install neuron-ray-vllm-inference ./inference-charts --values values-llama-31-8b-ray-vllm-neuron.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install neuron-ray-vllm-inference ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-31-8b-ray-vllm-neuron.yaml
 ```
 
 ### Deploy GPU Ray-VLLM with Mistral Small 24B model
 
 ```bash
-helm install gpu-ray-vllm-mistral ./inference-charts --values values-mistral-small-24b-ray-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-ray-vllm-mistral ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-mistral-small-24b-ray-vllm.yaml
 ```
 
 ### Deploy GPU Ray-VLLM with Llama 3.2 1B model with autoscaling
 
 ```bash
-helm install gpu-ray-vllm-autoscale ./inference-charts --values values-llama-32-1b-ray-vllm-autoscaling.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-ray-vllm-autoscale ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-32-1b-ray-vllm-autoscaling.yaml
 ```
 
 ### Deploy GPU Triton-VLLM with Llama 3.2 1B
 
 ```bash
-helm install gpu-triton-vllm ./inference-charts --values values-llama-32-1b-triton-vllm-gpu.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpu-triton-vllm ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-32-1b-triton-vllm-gpu.yaml
 ```
 
 ### Deploy GPT OSS 20B with VLLM
 
 ```bash
-helm install gpt-oss-vllm ./inference-charts --values values-gpt-oss-20b-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install gpt-oss-vllm ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-gpt-oss-20b-vllm.yaml
 ```
 
 ### Deploy Qwen3 1.7B with VLLM
 
 ```bash
-helm install qwen3-vllm ./inference-charts --values values-qwen3-1.7b-vllm.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install qwen3-vllm ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-qwen3-1.7b-vllm.yaml
 ```
 
 ### Deploy Diffusers Models
@@ -566,37 +614,55 @@ helm install qwen3-vllm ./inference-charts --values values-qwen3-1.7b-vllm.yaml
 #### Deploy FLUX.1 Schnell for image generation
 
 ```bash
-helm install flux-diffusers ./inference-charts --values values-flux-1-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install flux-diffusers ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-flux-1-diffusers.yaml
 ```
 
 #### Deploy Stable Diffusion XL Base 1.0
 
 ```bash
-helm install sdxl-diffusers ./inference-charts --values values-stable-diffusion-xl-base-1-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install sdxl-diffusers ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-stable-diffusion-xl-base-1-diffusers.yaml
 ```
 
 #### Deploy Stable Diffusion 3.5 Large
 
 ```bash
-helm install sd3-diffusers ./inference-charts --values values-stable-diffusion-3.5-large-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install sd3-diffusers ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers.yaml
 ```
 
 #### Deploy Kolors for artistic image generation
 
 ```bash
-helm install kolors-diffusers ./inference-charts --values values-kolors-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install kolors-diffusers ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-kolors-diffusers.yaml
 ```
 
 #### Deploy OmniGen for multi-modal generation
 
 ```bash
-helm install omnigen-diffusers ./inference-charts --values values-omni-gen-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install omnigen-diffusers ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-omni-gen-diffusers.yaml
 ```
 
 #### Deploy Latent Diffusion
 
 ```bash
-helm install latent-diffusion ./inference-charts --values values-latent-diffusion-diffusers.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install latent-diffusion ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-latent-diffusion-diffusers.yaml
 ```
 
 ### NVIDIA NIM Examples
@@ -629,7 +695,10 @@ kubectl create secret docker-registry ngc-secret \
 #### Deploy NIM Llama 3.1 8B Instruct (LLM)
 
 ```bash
-helm install nim-llama-31-8b ./inference-charts --values values-llama-3-8b-instruct-nim
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install nim-llama-31-8b ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
 ```
 
 **Test the LLM:**
@@ -650,7 +719,10 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 #### Deploy NIM Stable Diffusion 3.5 Large (Image Generation)
 
 ```bash
-helm install nim-sd-large ./inference-charts --values values-stable-diffusion-3.5-large-diffusers-nim.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install nim-sd-large ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
 ```
 
 **Test image generation:**
@@ -726,7 +798,10 @@ Then in your API request:
 #### Copy Llama 3 8B model from Hugging Face to S3
 
 ```bash
-helm install s3-copy-llama3 ./inference-charts --values values-s3-copy-llama3-8b.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install s3-copy-llama3 ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-s3-copy-llama3-8b.yaml
 ```
 
 #### Custom S3 Model Copy
@@ -745,7 +820,10 @@ serviceAccountName: s3-copy-service-account
 Then deploy:
 
 ```bash
-helm install custom-s3-copy ./inference-charts --values custom-s3-copy-values.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install custom-s3-copy ai-on-eks/inference-charts -f custom-s3-copy-values.yaml
 ```
 
 ### Custom Deployment
@@ -815,7 +893,10 @@ modelParameters:
 Then install the chart with your custom values:
 
 ```bash
-helm install custom-inference ./inference-charts --values custom-values.yaml
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install custom-inference ai-on-eks/inference-charts -f custom-values.yaml
 ```
 
 ## API Endpoints

--- a/charts/inference-charts/templates/NOTES.txt
+++ b/charts/inference-charts/templates/NOTES.txt
@@ -26,6 +26,7 @@ The following service is available:
   http://{{ .Release.Name }}-{{ .Values.inference.accelerator }}-ray-vllm:{{ .Values.service.port }}/v1/chat/completions
 {{- end }}
 
+{{- if ne .Values.inference.framework "nim" }}
 Example curl command to test the API:
 
 curl -X POST \
@@ -49,10 +50,28 @@ Available API endpoints:
 - /v1/chat/completions - Chat completion API
 - /metrics - Prometheus metrics endpoint
 {{- else }}
+NVIDIA NIM Deployment:
+
+Service: {{ .Values.inference.serviceName }}
+Namespace: {{ .Values.inference.serviceNamespace }}
+
+IMPORTANT: NIM deployments take time to become ready:
+- LLM models (like Llama): 10-15 minutes
+- Diffusion models (like Stable Diffusion): 20-30 minutes
+
+Monitor deployment progress:
+  $ kubectl logs -f deployment/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+Check when ready:
+  $ kubectl get deployment {{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+For detailed API usage and testing examples, see the README under the header NVIDIA NIM Examples
+{{- end }}
+{{- else }}
 No inference service was enabled. Please set both accelerator and framework values:
 
 - inference.accelerator: gpu or neuron
-- inference.framework: vllm or ray-vllm
+- inference.framework: vllm, ray-vllm, triton-vllm, diffusers, lws-vllm, aibrix, or nim
 
 For example:
   $ helm upgrade {{ .Release.Name }} . --set inference.accelerator=gpu --set inference.framework=vllm

--- a/charts/inference-charts/templates/nim-deployment.yaml
+++ b/charts/inference-charts/templates/nim-deployment.yaml
@@ -1,0 +1,159 @@
+{{- if eq .Values.inference.framework "nim" }}
+{{- if .Values.inference.modelServer.deployment.nim.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.inference.modelServer.deployment.nim.persistence.claimName }}
+  namespace: {{ .Values.inference.serviceNamespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.inference.modelServer.deployment.nim.persistence.size }}
+  {{- if .Values.inference.modelServer.deployment.nim.persistence.storageClassName }}
+  storageClassName: {{ .Values.inference.modelServer.deployment.nim.persistence.storageClassName }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.inference.serviceName }}
+  namespace: {{ .Values.inference.serviceNamespace }}
+  labels:
+    {{- include "inference-charts.labels" . | nindent 4 }}
+    "app.kubernetes.io/component": "{{ .Values.inference.serviceName }}"
+spec:
+  replicas: {{ .Values.inference.modelServer.deployment.replicas }}
+  selector:
+    matchLabels:
+      {{- include "inference-charts.selectorLabels" . | nindent 6 }}
+      "app.kubernetes.io/component": "{{ .Values.inference.serviceName }}"
+  template:
+    metadata:
+      labels:
+        {{- include "inference-charts.selectorLabels" . | nindent 8 }}
+        "app.kubernetes.io/component": "{{ .Values.inference.serviceName }}"
+      {{- with .Values.inference.modelServer.deployment.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- with .Values.inference.modelServer.deployment.nim.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.inference.modelServer.deployment.nim.initContainers.fixPermissions.enabled }}
+      - name: fix-permissions
+        image: {{ .Values.inference.modelServer.deployment.nim.initContainers.fixPermissions.image }}
+        command: ['sh', '-c', 'chown -R 1000:1000 /opt/nim/.cache && chmod -R 755 /opt/nim/.cache']
+        volumeMounts:
+        - name: cache
+          mountPath: /opt/nim/.cache
+        securityContext:
+          runAsUser: 0
+      {{- end }}
+      {{- if .Values.inference.modelServer.deployment.nim.initContainers.clearTrtCache.enabled }}
+      - name: clear-trt-cache
+        image: {{ .Values.inference.modelServer.deployment.nim.initContainers.clearTrtCache.image }}
+        command: ['sh', '-c', 'rm -rf /opt/nim/.cache/trt_engines_cache/ && echo "TensorRT cache cleared for L40S compatibility"']
+        volumeMounts:
+        - name: cache
+          mountPath: /opt/nim/.cache
+        securityContext:
+          runAsUser: 0
+      {{- end }}
+      containers:
+      - name: nim-server
+        image: "{{ .Values.inference.modelServer.image.repository }}:{{ .Values.inference.modelServer.image.tag }}"
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        {{- range $key, $value := .Values.inference.modelServer.deployment.nim.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        - name: NGC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.inference.modelServer.deployment.nim.secrets.ngcApiKey.name }}
+              key: {{ .Values.inference.modelServer.deployment.nim.secrets.ngcApiKey.key }}
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.inference.modelServer.deployment.nim.secrets.hfToken.name }}
+              key: {{ .Values.inference.modelServer.deployment.nim.secrets.hfToken.key }}
+        {{- with .Values.inference.modelServer.deployment.nim.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.inference.modelServer.deployment.resources.gpu | nindent 10 }}
+        volumeMounts:
+        - name: cache
+          mountPath: /opt/nim/.cache
+        {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+        - name: dev-shm
+          mountPath: /dev/shm
+        {{- end }}
+        {{- with .Values.inference.modelServer.deployment.nim.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.inference.modelServer.deployment.nim.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- if .Values.inference.modelServer.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.inference.modelServer.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.inference.modelServer.deployment.tolerations }}
+      tolerations:
+        {{- toYaml .Values.inference.modelServer.deployment.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.inference.modelServer.deployment.affinity }}
+      affinity:
+        {{- toYaml .Values.inference.modelServer.deployment.affinity | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: cache
+        persistentVolumeClaim:
+          claimName: {{ .Values.inference.modelServer.deployment.nim.persistence.claimName }}
+      {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+      - name: dev-shm
+        emptyDir:
+          medium: {{ .Values.inference.modelServer.deployment.nim.shm.medium }}
+          sizeLimit: {{ .Values.inference.modelServer.deployment.nim.shm.sizeLimit }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.inference.serviceName }}
+  namespace: {{ .Values.inference.serviceNamespace }}
+  labels:
+    {{- include "inference-charts.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "inference-charts.selectorLabels" . | nindent 4 }}
+    "app.kubernetes.io/component": "{{ .Values.inference.serviceName }}"
+{{- end }}

--- a/charts/inference-charts/templates/nim-deployment.yaml
+++ b/charts/inference-charts/templates/nim-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.inference.framework "nim" }}
+{{- if eq .Values.inference.framework "nim-container" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/inference-charts/templates/nim-deployment.yaml
+++ b/charts/inference-charts/templates/nim-deployment.yaml
@@ -80,20 +80,29 @@ spec:
       tolerations:
         {{- toYaml .Values.inference.modelServer.deployment.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.inference.modelServer.deployment.affinity }}
+      {{- if .Values.inference.modelServer.deployment.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        {{- range .Values.inference.modelServer.deployment.topologySpreadConstraints.constraints }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              "app.kubernetes.io/component": "{{$.Values.inference.serviceName}}"
+        {{- end }}
+      {{- end }}
+      {{- if and .Values.inference.modelServer.deployment.podAffinity.enabled .Values.inference.modelServer.deployment.podAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
       affinity:
-        {{- if .Values.inference.modelServer.deployment.affinity.nodeAffinity }}
-        nodeAffinity:
-          {{- toYaml .Values.inference.modelServer.deployment.affinity.nodeAffinity | nindent 10 }}
-        {{- end }}
-        {{- if and .Values.inference.modelServer.deployment.affinity.podAffinity.enabled .Values.inference.modelServer.deployment.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
         podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchLabels:
-                  "app.kubernetes.io/component": "{{$.Values.inference.serviceName}}"
-        {{- end }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            {{- range .Values.inference.modelServer.deployment.podAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+            - weight: {{ .weight }}
+              podAffinityTerm:
+                topologyKey: {{ .podAffinityTerm.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    "app.kubernetes.io/component": "{{$.Values.inference.serviceName}}"
+            {{- end }}
       {{- end }}
       {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
       volumes:

--- a/charts/inference-charts/templates/nim-deployment.yaml
+++ b/charts/inference-charts/templates/nim-deployment.yaml
@@ -1,21 +1,4 @@
 {{- if eq .Values.inference.framework "nim" }}
-{{- if .Values.inference.modelServer.deployment.nim.persistence.enabled }}
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.inference.modelServer.deployment.nim.persistence.claimName }}
-  namespace: {{ .Values.inference.serviceNamespace }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.inference.modelServer.deployment.nim.persistence.size }}
-  {{- if .Values.inference.modelServer.deployment.nim.persistence.storageClassName }}
-  storageClassName: {{ .Values.inference.modelServer.deployment.nim.persistence.storageClassName }}
-  {{- end }}
----
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,27 +31,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-      {{- if .Values.inference.modelServer.deployment.nim.initContainers.fixPermissions.enabled }}
-      - name: fix-permissions
-        image: {{ .Values.inference.modelServer.deployment.nim.initContainers.fixPermissions.image }}
-        command: ['sh', '-c', 'chown -R 1000:1000 /opt/nim/.cache && chmod -R 755 /opt/nim/.cache']
-        volumeMounts:
-        - name: cache
-          mountPath: /opt/nim/.cache
-        securityContext:
-          runAsUser: 0
-      {{- end }}
-      {{- if .Values.inference.modelServer.deployment.nim.initContainers.clearTrtCache.enabled }}
-      - name: clear-trt-cache
-        image: {{ .Values.inference.modelServer.deployment.nim.initContainers.clearTrtCache.image }}
-        command: ['sh', '-c', 'rm -rf /opt/nim/.cache/trt_engines_cache/ && echo "TensorRT cache cleared for L40S compatibility"']
-        volumeMounts:
-        - name: cache
-          mountPath: /opt/nim/.cache
-        securityContext:
-          runAsUser: 0
-      {{- end }}
       containers:
       - name: nim-server
         image: "{{ .Values.inference.modelServer.image.repository }}:{{ .Values.inference.modelServer.image.tag }}"
@@ -97,10 +59,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.inference.modelServer.deployment.resources.gpu | nindent 10 }}
-        volumeMounts:
-        - name: cache
-          mountPath: /opt/nim/.cache
         {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+        volumeMounts:
         - name: dev-shm
           mountPath: /dev/shm
         {{- end }}
@@ -122,13 +82,21 @@ spec:
       {{- end }}
       {{- if .Values.inference.modelServer.deployment.affinity }}
       affinity:
-        {{- toYaml .Values.inference.modelServer.deployment.affinity | nindent 8 }}
+        {{- if .Values.inference.modelServer.deployment.affinity.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml .Values.inference.modelServer.deployment.affinity.nodeAffinity | nindent 10 }}
+        {{- end }}
+        {{- if and .Values.inference.modelServer.deployment.affinity.podAffinity.enabled .Values.inference.modelServer.deployment.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  "app.kubernetes.io/component": "{{$.Values.inference.serviceName}}"
+        {{- end }}
       {{- end }}
-      volumes:
-      - name: cache
-        persistentVolumeClaim:
-          claimName: {{ .Values.inference.modelServer.deployment.nim.persistence.claimName }}
       {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+      volumes:
       - name: dev-shm
         emptyDir:
           medium: {{ .Values.inference.modelServer.deployment.nim.shm.medium }}

--- a/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
+++ b/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
@@ -14,11 +14,11 @@ inference:
     image:
       repository: nvcr.io/nim/meta/llama3-8b-instruct
       tag: latest
-    
+
     deployment:
       replicas: 1
       instanceType: g6e.2xlarge  # 1 GPU instance suitable for 8B model
-      
+
       resources:
         gpu:
           requests:
@@ -29,27 +29,9 @@ inference:
             cpu: "8"
             memory: "64Gi"
             nvidia.com/gpu: "1"
-      
+
       # NIM-specific configuration
       nim:
-        # Persistent volume for model cache 
-        # critical for performance - prevents repeated model loading
-        persistence:
-          enabled: true
-          size: 200Gi  # Llama 3 8B requires less storage than SD models
-          storageClassName: ""  # Use default storage class
-          claimName: nim-cache-pvc
-        
-        # Init containers for cache cleanup & management
-        # recommended for issues with model caching
-        initContainers:
-          fixPermissions:
-            enabled: true
-            image: busybox:1.35
-          clearTrtCache:
-            enabled: true
-            image: busybox:1.35
-        
         # NIM environment variables for LLM
         env:
           # For full list: https://docs.nvidia.com/nim/large-language-models/latest/configuration.html
@@ -60,25 +42,25 @@ inference:
           # LLM-specific settings
           NIM_MAX_MODEL_LEN: "4096"  # Maximum sequence length
           NIM_TENSOR_PARALLEL_SIZE: "1"  # Number of GPUs for tensor parallelism
-        
+
         # Security context
         securityContext:
           capabilities:
             add: ["SYS_ADMIN"]
           runAsUser: 1000
           runAsGroup: 1000
-        
+
         podSecurityContext:
           fsGroup: 1000
           runAsUser: 1000
           runAsGroup: 1000
-        
+
         # Shared memory configuration
         shm:
           enabled: true
           medium: Memory
           sizeLimit: 1Gi
-        
+
         # Health probes (NIM LLM takes 10-15 minutes to start)
         livenessProbe:
           httpGet:
@@ -88,7 +70,7 @@ inference:
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3
-        
+
         readinessProbe:
           httpGet:
             path: /v1/health/ready
@@ -98,7 +80,7 @@ inference:
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
-        
+
         # NGC and HF secrets
         secrets:
           ngcApiKey:
@@ -107,13 +89,13 @@ inference:
           hfToken:
             name: hf-token
             key: HF_TOKEN
-      
+
       # Optimized for Llama 3: Works on Ampere (A), Lovelace (L), Hopper (H), and Blackwell (B) architectures.
       # g6e instances utilize L40S (Lovelace) GPUs.
       # For 8B model, g6e.2xlarge (1 GPU) is sufficient
       nodeSelector:
         karpenter.sh/nodepool: g6e-nvidia
-      
+
       # Tolerations
       tolerations:
         - key: "nvidia.com/gpu"
@@ -123,11 +105,10 @@ inference:
           operator: "Equal"
           value: "g6e-nvidia"
           effect: "NoSchedule"
-      
+
       # Pod annotations
-      annotations:
-        karpenter.sh/do-not-evict: "true"
-      
+      annotations: {}
+
       # Affinity - prefer on-demand instances, adjust as needed
       affinity:
         nodeAffinity:
@@ -139,6 +120,9 @@ inference:
                     operator: In
                     values:
                       - on-demand
+        podAffinity:
+          enabled: true
+          requiredDuringSchedulingIgnoredDuringExecution: true
 
 # Image pull secrets for NGC registry
 imagePullSecrets:

--- a/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
+++ b/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
@@ -30,65 +30,16 @@ inference:
             memory: "64Gi"
             nvidia.com/gpu: "1"
 
-      # NIM-specific configuration
+      # NIM-specific configuration (inherits from values.yaml nim section)
       nim:
-        # NIM environment variables for LLM
+        # LLM-specific environment variables
+        # For full list: https://docs.nvidia.com/nim/large-language-models/latest/configuration.html
         env:
-          # For full list: https://docs.nvidia.com/nim/large-language-models/latest/configuration.html
           NIM_MODEL_NAME: "meta/llama3-8b-instruct"
-          NVIDIA_VISIBLE_DEVICES: "all"
-          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-          NIM_CACHE_PATH: "/opt/nim/.cache"
-          # LLM-specific settings
           NIM_MAX_MODEL_LEN: "4096"  # Maximum sequence length
           NIM_TENSOR_PARALLEL_SIZE: "1"  # Number of GPUs for tensor parallelism
-
-        # Security context
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN"]
-          runAsUser: 1000
-          runAsGroup: 1000
-
-        podSecurityContext:
-          fsGroup: 1000
-          runAsUser: 1000
-          runAsGroup: 1000
-
-        # Shared memory configuration
-        shm:
-          enabled: true
-          medium: Memory
-          sizeLimit: 1Gi
-
-        # Health probes (NIM LLM takes 10-15 minutes to start)
-        livenessProbe:
-          httpGet:
-            path: /v1/health/live
-            port: 8000
-          initialDelaySeconds: 900  # 15 minutes for LLM
-          periodSeconds: 30
-          timeoutSeconds: 10
-          failureThreshold: 3
-
-        readinessProbe:
-          httpGet:
-            path: /v1/health/ready
-            port: 8000
-          # LLMs typically load faster than diffusion models
-          initialDelaySeconds: 900  # 15 minutes
-          periodSeconds: 10
-          timeoutSeconds: 10
-          failureThreshold: 3
-
-        # NGC and HF secrets
-        secrets:
-          ngcApiKey:
-            name: ngc-api
-            key: NGC_API_KEY
-          hfToken:
-            name: hf-token
-            key: HF_TOKEN
+        # Note: Common NIM settings (NVIDIA_VISIBLE_DEVICES, security context, health probes, secrets)
+        # are inherited from values.yaml and can be overridden here if needed
 
       # Optimized for Llama 3: Works on Ampere (A), Lovelace (L), Hopper (H), and Blackwell (B) architectures.
       # g6e instances utilize L40S (Lovelace) GPUs.
@@ -108,21 +59,6 @@ inference:
 
       # Pod annotations
       annotations: {}
-
-      # Affinity - prefer on-demand instances, adjust as needed
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: karpenter.sh/capacity-type
-                    operator: In
-                    values:
-                      - on-demand
-        podAffinity:
-          enabled: true
-          requiredDuringSchedulingIgnoredDuringExecution: true
 
 # Image pull secrets for NGC registry
 imagePullSecrets:

--- a/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
+++ b/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
@@ -8,7 +8,7 @@ inference:
   serviceName: nim-llama-31-8b
   serviceNamespace: default # Recommended: Move to a dedicated namespace (e.g., 'nim') to ensure service isolation.
   accelerator: gpu
-  framework: nim
+  framework: nim-container
 
   modelServer:
     image:

--- a/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
+++ b/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
@@ -1,0 +1,145 @@
+# NVIDIA NIM Llama 3.1 8B Instruct
+# Optimized for GPU inference with TensorRT-LLM
+
+# NIM doesn't use the model parameter the same way - it's baked into the container
+model: meta/llama3-8b-instruct
+
+inference:
+  serviceName: nim-llama-31-8b
+  serviceNamespace: default # Recommended: Move to a dedicated namespace (e.g., 'nim') to ensure service isolation.
+  accelerator: gpu
+  framework: nim
+
+  modelServer:
+    image:
+      repository: nvcr.io/nim/meta/llama3-8b-instruct
+      tag: latest
+    
+    deployment:
+      replicas: 1
+      instanceType: g6e.2xlarge  # 1 GPU instance suitable for 8B model
+      
+      resources:
+        gpu:
+          requests:
+            cpu: "4"
+            memory: "32Gi"
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "8"
+            memory: "64Gi"
+            nvidia.com/gpu: "1"
+      
+      # NIM-specific configuration
+      nim:
+        # Persistent volume for model cache 
+        # critical for performance - prevents repeated model loading
+        persistence:
+          enabled: true
+          size: 200Gi  # Llama 3 8B requires less storage than SD models
+          storageClassName: ""  # Use default storage class
+          claimName: nim-cache-pvc
+        
+        # Init containers for cache cleanup & management
+        # recommended for issues with model caching
+        initContainers:
+          fixPermissions:
+            enabled: true
+            image: busybox:1.35
+          clearTrtCache:
+            enabled: true
+            image: busybox:1.35
+        
+        # NIM environment variables for LLM
+        env:
+          # For full list: https://docs.nvidia.com/nim/large-language-models/latest/configuration.html
+          NIM_MODEL_NAME: "meta/llama3-8b-instruct"
+          NVIDIA_VISIBLE_DEVICES: "all"
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+          NIM_CACHE_PATH: "/opt/nim/.cache"
+          # LLM-specific settings
+          NIM_MAX_MODEL_LEN: "4096"  # Maximum sequence length
+          NIM_TENSOR_PARALLEL_SIZE: "1"  # Number of GPUs for tensor parallelism
+        
+        # Security context
+        securityContext:
+          capabilities:
+            add: ["SYS_ADMIN"]
+          runAsUser: 1000
+          runAsGroup: 1000
+        
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+        
+        # Shared memory configuration
+        shm:
+          enabled: true
+          medium: Memory
+          sizeLimit: 1Gi
+        
+        # Health probes (NIM LLM takes 10-15 minutes to start)
+        livenessProbe:
+          httpGet:
+            path: /v1/health/live
+            port: 8000
+          initialDelaySeconds: 900  # 15 minutes for LLM
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        readinessProbe:
+          httpGet:
+            path: /v1/health/ready
+            port: 8000
+          # LLMs typically load faster than diffusion models
+          initialDelaySeconds: 900  # 15 minutes
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        # NGC and HF secrets
+        secrets:
+          ngcApiKey:
+            name: ngc-api
+            key: NGC_API_KEY
+          hfToken:
+            name: hf-token
+            key: HF_TOKEN
+      
+      # Optimized for Llama 3: Works on Ampere (A), Lovelace (L), Hopper (H), and Blackwell (B) architectures.
+      # g6e instances utilize L40S (Lovelace) GPUs.
+      # For 8B model, g6e.2xlarge (1 GPU) is sufficient
+      nodeSelector:
+        karpenter.sh/nodepool: g6e-nvidia
+      
+      # Tolerations
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "karpenter.sh/nodepool"
+          operator: "Equal"
+          value: "g6e-nvidia"
+          effect: "NoSchedule"
+      
+      # Pod annotations
+      annotations:
+        karpenter.sh/do-not-evict: "true"
+      
+      # Affinity - prefer on-demand instances, adjust as needed
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: karpenter.sh/capacity-type
+                    operator: In
+                    values:
+                      - on-demand
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret

--- a/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
+++ b/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
@@ -30,43 +30,22 @@ inference:
             memory: "128Gi"
             nvidia.com/gpu: "1"
 
-      # NIM-specific configuration
+      # NIM-specific configuration (inherits from values.yaml nim section)
       nim:
-        # NIM environment variables
+        # Diffusion model-specific environment variables
+        # For full list: https://docs.nvidia.com/nim/visual-genai/1.0.0/configuration.html
         env:
-          # For full list: https://docs.nvidia.com/nim/visual-genai/1.0.0/configuration.html
           NIM_MODEL_NAME: "stable-diffusion-3.5-large"
           NIM_ALLOW_UNCHECKED_GENERATION: "true" #use "disable_safety_checker" in request
           NIM_MODEL_VARIANT: "base"
-          NVIDIA_VISIBLE_DEVICES: "all"
-          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-          NIM_CACHE_PATH: "/opt/nim/.cache"
           FORCE_REBUILD_ENGINES: "true"
 
-        # Security context
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN"]
-          runAsUser: 1000
-          runAsGroup: 1000
-
-        podSecurityContext:
-          fsGroup: 1000
-          runAsUser: 1000
-          runAsGroup: 1000
-
-        # Shared memory configuration
-        shm:
-          enabled: true
-          medium: Memory
-          sizeLimit: 1Gi
-
-        # Health probes (NIM takes 20-30 minutes to start)
+        # Override health probes for diffusion models (take longer to start than LLMs)
         livenessProbe:
           httpGet:
             path: /v1/health/live
             port: 8000
-          initialDelaySeconds: 1800
+          initialDelaySeconds: 1800  # 30 minutes for diffusion models
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3
@@ -77,19 +56,12 @@ inference:
             port: 8000
           # High initial delay due to potential model loading
           # If using a preloaded model (e.g. from a pre-loaded volume), this can be much lower
-          initialDelaySeconds: 1800
+          initialDelaySeconds: 1800  # 30 minutes
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
-
-        # NGC and HF secrets
-        secrets:
-          ngcApiKey:
-            name: ngc-api
-            key: NGC_API_KEY
-          hfToken:
-            name: hf-token
-            key: HF_TOKEN
+        # Note: Common NIM settings (NVIDIA_VISIBLE_DEVICES, security context, secrets)
+        # are inherited from values.yaml and can be overridden here if needed
 
       # Optimized for SD 3.5: Lovelace (L), Hopper (H), and Blackwell (B) architectures.
       # g6e instances utilize L40S (Lovelace) GPUs.
@@ -108,21 +80,6 @@ inference:
 
       # Pod annotations
       annotations: {}
-
-      # Affinity - prefer on-demand instances, adjust as needed
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: karpenter.sh/capacity-type
-                    operator: In
-                    values:
-                      - on-demand
-        podAffinity:
-          enabled: true
-          requiredDuringSchedulingIgnoredDuringExecution: true
 
 # Image pull secrets for NGC registry
 imagePullSecrets:

--- a/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
+++ b/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
@@ -1,0 +1,145 @@
+# NVIDIA NIM Stable Diffusion 3.5 Large
+# Optimized for L40S GPUs (g6e.12xlarge instances)
+
+# NIM doesn't use the model parameter the same way - it's baked into the container
+model: stabilityai/stable-diffusion-3.5-large
+
+inference:
+  serviceName: nim-sd-35-large
+  serviceNamespace: default # Recommended: Move to a dedicated namespace (e.g., 'nim') to ensure service isolation.
+  accelerator: gpu
+  framework: nim
+
+  modelServer:
+    image:
+      repository: nvcr.io/nim/stabilityai/stable-diffusion-3.5-large
+      tag: latest
+    
+    deployment:
+      replicas: 1
+      instanceType: g6e.4xlarge  # L40S instance
+      
+      resources:
+        gpu:
+          requests:
+            cpu: "8"
+            memory: "64Gi"
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "16"
+            memory: "128Gi"
+            nvidia.com/gpu: "1"
+      
+      # NIM-specific configuration
+      nim:
+        # Persistent volume for model cache 
+        # critical for performance - prevents repeated model loading
+        persistence:
+          enabled: true
+          size: 500Gi
+          storageClassName: ""  # Use default storage class
+          claimName: nim-cache-pvc
+        
+        # Init containers for cache cleanup & management
+        # recommended for issues with model caching
+        initContainers:
+          fixPermissions:
+            enabled: true
+            image: busybox:1.35
+          clearTrtCache:
+            enabled: true
+            image: busybox:1.35
+        
+        # NIM environment variables
+        env:
+          # For full list: https://docs.nvidia.com/nim/visual-genai/1.0.0/configuration.html
+          NIM_MODEL_NAME: "stable-diffusion-3.5-large"
+          NIM_ALLOW_UNCHECKED_GENERATION: "true" #use "disable_safety_checker" in request
+          NIM_MODEL_VARIANT: "base"
+          NVIDIA_VISIBLE_DEVICES: "all"
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+          NIM_CACHE_PATH: "/opt/nim/.cache"
+          FORCE_REBUILD_ENGINES: "true"
+        
+        # Security context
+        securityContext:
+          capabilities:
+            add: ["SYS_ADMIN"]
+          runAsUser: 1000
+          runAsGroup: 1000
+        
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+        
+        # Shared memory configuration
+        shm:
+          enabled: true
+          medium: Memory
+          sizeLimit: 1Gi
+        
+        # Health probes (NIM takes 20-30 minutes to start)
+        livenessProbe:
+          httpGet:
+            path: /v1/health/live
+            port: 8000
+          initialDelaySeconds: 1800
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        readinessProbe:
+          httpGet:
+            path: /v1/health/ready
+            port: 8000
+          # High initial delay due to potential model loading
+          # If using a preloaded model (e.g. from a pre-loaded volume), this can be much lower
+          initialDelaySeconds: 1800
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        # NGC and HF secrets
+        secrets:
+          ngcApiKey:
+            name: ngc-api
+            key: NGC_API_KEY
+          hfToken:
+            name: hf-token
+            key: HF_TOKEN
+      
+      # Optimized for SD 3.5: Lovelace (L), Hopper (H), and Blackwell (B) architectures.
+      # g6e instances utilize L40S (Lovelace) GPUs.
+      nodeSelector:
+        karpenter.sh/nodepool: g6e-nvidia
+      
+      # Tolerations
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "karpenter.sh/nodepool"
+          operator: "Equal"
+          value: "g6e-nvidia"
+          effect: "NoSchedule"
+      
+      # Pod annotations
+      annotations:
+        karpenter.sh/do-not-evict: "true"
+      
+      # Affinity - prefer on-demand instances, adjust as needed
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: karpenter.sh/capacity-type
+                    operator: In
+                    values:
+                      - on-demand
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret

--- a/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
+++ b/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
@@ -8,7 +8,7 @@ inference:
   serviceName: nim-sd-35-large
   serviceNamespace: default # Recommended: Move to a dedicated namespace (e.g., 'nim') to ensure service isolation.
   accelerator: gpu
-  framework: nim
+  framework: nim-container
 
   modelServer:
     image:

--- a/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
+++ b/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
@@ -1,5 +1,5 @@
 # NVIDIA NIM Stable Diffusion 3.5 Large
-# Optimized for L40S GPUs (g6e.12xlarge instances)
+# Optimized for L40S GPUs (g6e instances)
 
 # NIM doesn't use the model parameter the same way - it's baked into the container
 model: stabilityai/stable-diffusion-3.5-large
@@ -14,11 +14,11 @@ inference:
     image:
       repository: nvcr.io/nim/stabilityai/stable-diffusion-3.5-large
       tag: latest
-    
+
     deployment:
       replicas: 1
       instanceType: g6e.4xlarge  # L40S instance
-      
+
       resources:
         gpu:
           requests:
@@ -29,27 +29,9 @@ inference:
             cpu: "16"
             memory: "128Gi"
             nvidia.com/gpu: "1"
-      
+
       # NIM-specific configuration
       nim:
-        # Persistent volume for model cache 
-        # critical for performance - prevents repeated model loading
-        persistence:
-          enabled: true
-          size: 500Gi
-          storageClassName: ""  # Use default storage class
-          claimName: nim-cache-pvc
-        
-        # Init containers for cache cleanup & management
-        # recommended for issues with model caching
-        initContainers:
-          fixPermissions:
-            enabled: true
-            image: busybox:1.35
-          clearTrtCache:
-            enabled: true
-            image: busybox:1.35
-        
         # NIM environment variables
         env:
           # For full list: https://docs.nvidia.com/nim/visual-genai/1.0.0/configuration.html
@@ -60,25 +42,25 @@ inference:
           NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
           NIM_CACHE_PATH: "/opt/nim/.cache"
           FORCE_REBUILD_ENGINES: "true"
-        
+
         # Security context
         securityContext:
           capabilities:
             add: ["SYS_ADMIN"]
           runAsUser: 1000
           runAsGroup: 1000
-        
+
         podSecurityContext:
           fsGroup: 1000
           runAsUser: 1000
           runAsGroup: 1000
-        
+
         # Shared memory configuration
         shm:
           enabled: true
           medium: Memory
           sizeLimit: 1Gi
-        
+
         # Health probes (NIM takes 20-30 minutes to start)
         livenessProbe:
           httpGet:
@@ -88,7 +70,7 @@ inference:
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3
-        
+
         readinessProbe:
           httpGet:
             path: /v1/health/ready
@@ -99,7 +81,7 @@ inference:
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
-        
+
         # NGC and HF secrets
         secrets:
           ngcApiKey:
@@ -108,12 +90,12 @@ inference:
           hfToken:
             name: hf-token
             key: HF_TOKEN
-      
+
       # Optimized for SD 3.5: Lovelace (L), Hopper (H), and Blackwell (B) architectures.
       # g6e instances utilize L40S (Lovelace) GPUs.
       nodeSelector:
         karpenter.sh/nodepool: g6e-nvidia
-      
+
       # Tolerations
       tolerations:
         - key: "nvidia.com/gpu"
@@ -123,11 +105,10 @@ inference:
           operator: "Equal"
           value: "g6e-nvidia"
           effect: "NoSchedule"
-      
+
       # Pod annotations
-      annotations:
-        karpenter.sh/do-not-evict: "true"
-      
+      annotations: {}
+
       # Affinity - prefer on-demand instances, adjust as needed
       affinity:
         nodeAffinity:
@@ -139,6 +120,9 @@ inference:
                     operator: In
                     values:
                       - on-demand
+        podAffinity:
+          enabled: true
+          requiredDuringSchedulingIgnoredDuringExecution: true
 
 # Image pull secrets for NGC registry
 imagePullSecrets:

--- a/charts/inference-charts/values.yaml
+++ b/charts/inference-charts/values.yaml
@@ -93,6 +93,56 @@ inference:
             aws.amazon.com/neuron: 1
           limits:
             aws.amazon.com/neuron: 1
+      # NIM-specific configuration (NVIDIA Inference Microservices)
+      # These are default values that can be overridden in model-specific values files
+      nim:
+        # Common NIM environment variables
+        env:
+          NVIDIA_VISIBLE_DEVICES: "all"
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+          NIM_CACHE_PATH: "/opt/nim/.cache"
+
+        # Run as non-root user (required for NIM containers - do not comment out)
+        # NIM images are built to run as UID 1000 with pre-configured library paths
+        # Running as root will cause CUDA library loading failures
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+
+        # Shared memory configuration
+        shm:
+          enabled: true
+          medium: Memory
+          sizeLimit: 1Gi
+
+        # Health probes - common endpoints for NIM
+        livenessProbe:
+          httpGet:
+            path: /v1/health/live
+            port: 8000
+          initialDelaySeconds: 900  # Default for smaller models
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /v1/health/ready
+            port: 8000
+          initialDelaySeconds: 900  # Default for smaller models
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        # NGC and HuggingFace secrets
+        secrets:
+          ngcApiKey:
+            name: ngc-api
+            key: NGC_API_KEY
+          hfToken:
+            name: hf-token
+            key: HF_TOKEN
       # Topology constraints for pod scheduling
       topologySpreadConstraints:
         enabled: true


### PR DESCRIPTION
Issue #7 

*Description*:
This PR introduces the Helm charts and configuration templates required to deploy NVIDIA NIM (NVIDIA Inference Microservices) containers on Amazon EKS. This specifically provides a validated path for high-performance inference for two models:
a) MMDiT Text-to-image model :  `stable-diffusion-3.5-large`
b) LLM - `llama3-8b-instruct`   

*Key Changes*:
* Helm Chart Templates: Added support for NIM container deployment logic.
* Extensible Model Examples: Provided validated configurations for Stable Diffusion 3.5 and LLM use cases. The implementation is model-agnostic, providing a modular path to onboard any additional models available via NGC.
* Documentation: Updated README with instructions for configuring NGC secrets and deploying NIM-based workloads.

*Test Steps*:
* Deploy  EKS cluster `jark-stack` using the template from: https://github.com/awslabs/ai-on-eks/tree/main/infra/jark-stack. Once the cluster is provisioned, register your cluster as:

```bash
aws eks --region <your-region> describe-cluster --name jark-stack
```
* Create separate namespaces (best practice) for the two configs - `charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml` and `charts/inference-charts/values-llama-3-8b-instruct-nim.yaml`
```bash
kubectl create namespace nim-stabledisffusion

kubectl create namespace nim-llama3
```

* Create following secrets separately for each namespace: 

```bash
kubectl create secret docker-registry ngc-secret \
  --docker-server=nvcr.io \
  --docker-username='$oauthtoken' \
  --docker-password=<your-ngc-api-key> \
  --namespace=<correct-namespace>

kubectl create secret generic ngc-api \
  --from-literal=NGC_API_KEY=<your-ngc-api-key> \
  --namespace=<correct-namespace>

kubectl create secret generic hf-token \
  --from-literal=HF_TOKEN=<your-hf-token> \
  --namespace=<correct-namespace>
```

* Deploy the following charts:

```bash
helm install nim-sd-large ./charts/inference-charts \
  -f ./charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml \
  --set inference.serviceNamespace="nim-stabledisffusion"

helm install nim-llama ./charts/inference-charts \
  -f ./charts/inference-charts/values-llama-3-8b-instruct-nim.yaml \
  --set inference.serviceNamespace="nim-llama3"

```

* Wait for the pods to be Ready. May take up to 30 mins because of the large model size and the initial delay in health-probe. 

```bash
kubectl get pods -n nim-stabledisffusion
NAME                               READY   STATUS    RESTARTS   AGE
nim-sd-35-large-769b689577-fclq7   1/1     Running   0          4h17m

kubectl get pods -n nim-llama3
NAME                               READY   STATUS    RESTARTS   AGE
nim-llama-31-8b-587d7886b7-2sr4c   1/1     Running   0          4h45m
```

* Port forward as following for viewing swagger and running the models

```bash
#for stable diffusion
kubectl port-forward -n nim-stabledisffusion svc/nim-sd-35-large 8001:8000

#for llama:
kubectl port-forward -n nim-llama3 svc/nim-llama-31-8b 8002:8000
```

The swagger docs will be available at http://localhost:8001/docs (for stable-diffusion) and http://localhost:8002/docs (for llama)

<img width="1681" height="774" alt="sd-docs" src="https://github.com/user-attachments/assets/78e0fb19-1d76-4fbb-be69-d2c1b8ef2c60" />

<img width="1673" height="697" alt="llama-docs" src="https://github.com/user-attachments/assets/c6079827-1a08-47e4-ba06-afbcac8d2efd" />

* Run the models

The models can be run from the swagger documents. Here are sample cURL commands:
Stable Diffusion: 
```bash
curl -X 'POST' \
  'http://localhost:8001/v1/infer' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "prompt": "A coffee shop interior",
  "height": 1024,
  "width": 1024,
  "cfg_scale": 3.5,
  "mode": "base",
  "seed": 0,
  "steps": 50,
  "disable_safety_checker": false
}'
```

Llama: 

```bash
curl -X 'POST' \
  'http://localhost:8002/v1/chat/completions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "messages": [
    {
      "role": "user",
      "content": "Hello! How are you?"
    }
  ],
  "model": "meta/llama3-8b-instruct",
  "max_tokens": 50,
  "temperature": 1,
  "top_p": 1
}'
```

Sample Results (from the above queries) - taken from Postman: 

Stable Diffusion:

<img width="726" height="855" alt="sd-result" src="https://github.com/user-attachments/assets/91fcc959-a1e1-41a9-b7f7-6f2f2a2c1079" />

Llama:

<img width="831" height="861" alt="llama-result" src="https://github.com/user-attachments/assets/e6bd5992-0093-491e-9cd6-d5517f43e91d" />

*Note*: The stable diffusion model output is base-64 encoded. I used the following post-response script in Postman to render the image:

```javascript
const jsonData = pm.response.json();
const base64ImageString = jsonData.artifacts[0].base64; 

// This is a simple HTML template with a placeholder for the image source
const visualizerTemplate = `
  <p><strong>Generated Image:</strong></p>
  <img src="data:image/png;base64,{{image}}" alt="Base64 Image" style="max-width: 100%; max-height: 400px;" />
`;
// NOTE: Change 'image/png' to 'image/jpeg', 'image/gif', etc., if your image type is different.

// Pass the image data to the template and set the visualizer
pm.visualizer.set(visualizerTemplate, {
  image: base64ImageString
});
```

