### PR TITLE
feat: add Llama 4 vLLM values for Trainium2 and GPU Maverick

### DIFF
--- a/charts/inference-charts/values-llama-4-maverick-17b-vllm-neuron.yaml
+++ b/charts/inference-charts/values-llama-4-maverick-17b-vllm-neuron.yaml
@@ -1,0 +1,38 @@
+# Llama 4 Maverick (17B-128E) on Trainium2
+# Requires pre-compiled model artifacts
+
+model: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+
+modelParameters:
+  maxModelLen: 16384
+  maxNumSeqs: 1
+  tensorParallelSize: 64
+
+inference:
+  serviceName: llama-4-maverick-17b-vllm-nrn
+  serviceNamespace: default
+  accelerator: neuron
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: public.ecr.aws/neuron/pytorch-inference-neuronx
+      tag: 2.5.1-neuronx-py310-sdk2.21.0-ubuntu22.04
+    deployment:
+      resources:
+        neuron:
+          requests:
+            aws.amazon.com/neuron: 32
+            memory: 512Gi
+          limits:
+            aws.amazon.com/neuron: 32
+            memory: 768Gi
+      nodeSelector:
+        node.kubernetes.io/instance-type: trn2.48xlarge
+      tolerations:
+        - key: aws.amazon.com/neuron
+          operator: Exists
+          effect: NoSchedule
+    env:
+      VLLM_USE_V1: "1"
+      NEURON_COMPILED_ARTIFACTS: ""

--- a/charts/inference-charts/values-llama-4-maverick-17b-vllm.yaml
+++ b/charts/inference-charts/values-llama-4-maverick-17b-vllm.yaml
@@ -1,0 +1,29 @@
+# Llama 4 Maverick (17B-128E) on GPU with FP8 quantization
+# FP8 required due to memory constraints (800GB BF16 > 640GB p5.48xlarge)
+
+model: RedHatAI/Llama-4-Maverick-17B-128E-Instruct-FP8
+
+modelParameters:
+  gpuMemoryUtilization: 0.9
+  maxModelLen: 8192
+  tensorParallelSize: 8
+
+inference:
+  serviceName: llama-4-maverick-17b-vllm
+  serviceNamespace: default
+  accelerator: gpu
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: public.ecr.aws/deep-learning-containers/vllm
+      tag: 0.10.2-gpu-py312-ec2
+    deployment:
+      resources:
+        gpu:
+          requests:
+            nvidia.com/gpu: 8
+          limits:
+            nvidia.com/gpu: 8
+      nodeSelector:
+        node.kubernetes.io/instance-type: p5.48xlarge

--- a/charts/inference-charts/values-llama-4-scout-17b-vllm-neuron.yaml
+++ b/charts/inference-charts/values-llama-4-scout-17b-vllm-neuron.yaml
@@ -1,0 +1,39 @@
+# Llama 4 Scout (17B-16E) on Trainium2
+# Requires pre-compiled model artifacts - see NxD Inference tutorial
+# https://awsdocs-neuron.readthedocs-hosted.com/en/latest/libraries/nxd-inference/tutorials/llama4-tutorial.html
+
+model: meta-llama/Llama-4-Scout-17B-16E-Instruct
+
+modelParameters:
+  maxModelLen: 16384
+  maxNumSeqs: 1
+  tensorParallelSize: 64
+
+inference:
+  serviceName: llama-4-scout-17b-vllm-nrn
+  serviceNamespace: default
+  accelerator: neuron
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: public.ecr.aws/neuron/pytorch-inference-neuronx
+      tag: 2.5.1-neuronx-py310-sdk2.21.0-ubuntu22.04
+    deployment:
+      resources:
+        neuron:
+          requests:
+            aws.amazon.com/neuron: 32
+            memory: 512Gi
+          limits:
+            aws.amazon.com/neuron: 32
+            memory: 768Gi
+      nodeSelector:
+        node.kubernetes.io/instance-type: trn2.48xlarge
+      tolerations:
+        - key: aws.amazon.com/neuron
+          operator: Exists
+          effect: NoSchedule
+    env:
+      VLLM_USE_V1: "1"
+      NEURON_COMPILED_ARTIFACTS: ""  # Set via --set flag


### PR DESCRIPTION
- values-llama-4-scout-17b-vllm-neuron.yaml: Scout on Trainium2 (BF16)
- values-llama-4-maverick-17b-vllm-neuron.yaml: Maverick on Trainium2 (BF16)
- values-llama-4-maverick-17b-vllm.yaml: Maverick on GPU (FP8 quantized)

Trainium2 deployments require pre-compiled model artifacts. GPU Maverick uses FP8 quantization due to memory constraints.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
