### PR TITLE
Add NVIDIA NIM Operator support and clarify NIM container naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/charts/inference-charts/Chart.yaml
+++ b/charts/inference-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: inference-charts
 description: A Helm chart for AI on EKS
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.0.0"

--- a/charts/inference-charts/README.md
+++ b/charts/inference-charts/README.md
@@ -15,7 +15,8 @@ The chart supports the following deployment types:
 - GPU-based AIBrix deployments
 - GPU-based LeaderWorkerSet-VLLM deployments
 - GPU-based Diffusers deployments
-- GPU-based NVIDIA NIM deployments
+- GPU-based NVIDIA NIM Container deployments
+- GPU-based NVIDIA NIM Operator deployments
 - Neuron-based VLLM deployments
 - Neuron-based Ray-VLLM deployments
 - Neuron-based Triton-VLLM deployments (Coming Soon)
@@ -57,6 +58,17 @@ The chart supports the following deployment types:
 - Supports persistent cache for model artifacts
 - Longer startup time (20-30 minutes) for model optimization
 - Best for production deployments requiring maximum performance
+
+**NVIDIA NIM Operator Deployments** (`framework: nim-operator`):
+
+- NVIDIA Inference Microservices managed by the NIM Operator
+- Two-step deployment: NIMCache (pre-pulls model profiles) then NIMService (inference service)
+- Uses Kubernetes CRDs (NIMCache and NIMService) for declarative management
+- Optimized startup with pre-cached model profiles for specific GPU types
+- Shared persistent storage (EFS) for model artifacts across replicas
+- Faster scaling and replica startup compared to nim-container
+- Requires NVIDIA NIM Operator installed in cluster
+- Best for production deployments with multiple replicas or frequent scaling
 
 **Triton-VLLM Deployments** (`framework: triton-vllm`):
 
@@ -106,13 +118,13 @@ Before installing the chart, create a Kubernetes secret with your Hugging Face t
 kubectl create secret generic hf-token --from-literal=token=your_huggingface_token
 ```
 
-### Create NGC Token secret for model access (for NIM deployments)
+### Create NGC Token secret for model access (for NIM Container and Operator deployments)
 
 ```bash
 kubectl create secret generic ngc-api --from-literal=NGC_API_KEY=your_ngc_api_key
 ```
 
-### Create NGC Docker registry credentials (for NIM deployments)
+### Create NGC Docker registry credentials (for NIM Container and Operator deployments)
 
 ```bash
 kubectl create secret docker-registry ngc-secret \
@@ -129,7 +141,7 @@ The following table lists the configurable parameters of the inference-charts ch
 |--------------------------------------------------------------------------|-------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `global.image.pullPolicy`                                                | Global image pull policy                                                            | `IfNotPresent`                                                              |
 | `inference.accelerator`                                                  | Accelerator type to use (gpu or neuron)                                             | `gpu`                                                                       |
-| `inference.framework`                                                    | Framework type to use (vllm, ray-vllm, triton-vllm, aibrix, lws-vllm,  diffusers, or nim-container) | `vllm`                                                                      |
+| `inference.framework`                                                    | Framework type to use (vllm, ray-vllm, triton-vllm, aibrix, lws-vllm,  diffusers, nim-container, or nim-operator) | `vllm`                                                                      |
 | `inference.serviceName`                                                  | Name of the inference service                                                       | `inference`                                                                 |
 | `inference.serviceNamespace`                                             | Namespace for the inference service                                                 | `default`                                                                   |
 | `inference.modelServer.image.repository`                                 | Model server image repository                                                       | `vllm/vllm-openai`                                                          |
@@ -226,10 +238,19 @@ The chart includes pre-configured values files for the following models:
 - **Latent Diffusion**: `values-latent-diffusion-diffusers.yaml` (Diffusers)
 - **OmniGen**: `values-omni-gen-diffusers.yaml` (Diffusers)
 
-#### NVIDIA NIM Models
+#### NVIDIA NIM Models deployed with standalone NIM containers
 
-- **Llama 3.1 8B Instruct**: `values-llama-31-8b-nim.yaml` (NIM)
-- **Stable Diffusion 3.5 Large**: `values-stable-diffusion-3.5-large-diffusers-nim.yaml` (NIM)
+- **Llama 3.1 8B Instruct**: `values-llama-3-8b-instruct-nim-container.yaml` (NIM-container)
+- **Stable Diffusion 3.5 Large**: `values-stable-diffusion-3.5-large-diffusers-nim.yaml` (NIM-container)
+
+#### NVIDIA NIM Models deployed with NIM Operators
+- **Llama 3.1 8B Instruct**:
+  - Cache: `values-llama-31-8b-instruct-nim-operator-cache.yaml` (NIM-operator-cache)
+  - Service: `values-llama-31-8b-instruct-nim-operator-service.yaml` (NIM-operator-service)
+
+- **Llama 3.2 1B Instruct**:
+  - Cache: `values-llama-32-1b-instruct-nim-operator-cache.yaml` (NIM-operator-cache)
+  - Service: `values-llama-32-1b-instruct-nim-operator-service.yaml` (NIM-operator-service)
 
 ### Neuron Models
 
@@ -665,13 +686,13 @@ helm repo update
 helm install latent-diffusion ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-latent-diffusion-diffusers.yaml
 ```
 
-### NVIDIA NIM Examples
+### NVIDIA NIM CONTAINER Examples
 
-> **Note:** To set up an inference EKS cluster, follow instructions at: https://awslabs.github.io/ai-on-eks/docs/infra/inference-ready-cluster
+> **Note:** To set up an inference EKS cluster, follow instructions at: https://awslabs.github.io/ai-on-eks/docs/infra/inference/inference-ready-cluster
 
-#### Prerequisites for NIM Deployments
+#### Prerequisites for NIM Container Deployments
 
-Before deploying NIM, create the required secrets:
+Create the required secrets:
 
 ```bash
 # NGC API Key - visit https://catalog.ngc.nvidia.com/ to generate NGC keys
@@ -692,19 +713,19 @@ kubectl create secret docker-registry ngc-secret \
   -n default
 ```
 
-#### Deploy NIM Llama 3.1 8B Instruct (LLM)
+#### Deploy NIM Container Llama 3 8B Instruct (LLM)
 
 ```bash
 helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
 helm repo update
 
-helm install nim-llama-31-8b ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-3-8b-instruct-nim.yaml
+helm install nim-llama-3-8b ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-3-8b-instruct-nim-container.yaml
 ```
 
 **Test the LLM:**
 ```bash
 # Port forward
-kubectl port-forward svc/nim-llama-31-8b 8000:8000
+kubectl port-forward svc/nim-llama-3-8b 8000:8000
 
 # Test chat completion
 curl -X POST http://localhost:8000/v1/chat/completions \
@@ -716,13 +737,13 @@ curl -X POST http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-#### Deploy NIM Stable Diffusion 3.5 Large (Image Generation)
+#### Deploy NIM Container Stable Diffusion 3.5 Large (Image Generation)
 
 ```bash
 helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
 helm repo update
 
-helm install nim-sd-large ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim.yaml
+helm install nim-sd-large ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim-container.yaml
 ```
 
 **Test image generation:**
@@ -791,7 +812,86 @@ Then in your API request:
 - [NVIDIA NIM Documentation](https://docs.nvidia.com/nim/)
 - [NGC Catalog](https://catalog.ngc.nvidia.com/)
 - [Stable Diffusion NIM Guide](https://docs.nvidia.com/nim/visual-genai/)
-- [Main README](./README.md)
+
+
+### NVIDIA NIM OPERATOR Examples
+
+> **Note:** Set up an inference-ready EKS cluster with the NVIDIA NIM stack using the [cluster setup guide](https://awslabs.github.io/ai-on-eks/docs/infra/inference/inference-ready-cluster) and the [install script](https://github.com/awslabs/ai-on-eks/blob/main/infra/nvidia-nim/install.sh).
+
+**Prerequisites:**
+
+```bash
+# NGC API secret for authentication - visit https://catalog.ngc.nvidia.com/ to generate NGC keys
+kubectl create secret generic ngc-api \
+  --from-literal=NGC_API_KEY=<your-ngc-api-key> \
+  -n <namespace>
+
+# NGC pull secret for container registry
+kubectl create secret docker-registry ngc-secret \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password=<your-ngc-api-key> \
+  -n <namespace>
+```
+
+#### Deploy NIM Operator Llama 3.1 8B Instruct (LLM)
+
+The NIM Operator deployment uses two components: a **NIMCache** that pre-pulls and caches model profiles for faster startup, and a **NIMService** that serves the cached model.
+
+Step 1: Deploy the NIMCache to download and cache the model profiles:
+
+```bash
+helm repo add ai-on-eks https://awslabs.github.io/ai-on-eks-charts/
+helm repo update
+
+helm install nim-llama-cache ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-cache.yaml
+```
+
+Wait for the NIMCache to be ready:
+
+```bash
+kubectl wait --for=condition=Ready nimcache/meta-llama-3-1-8b-instruct -n default --timeout=600s
+
+# see the downloaded model profiles
+kubectl get nimcache meta-llama-3-1-8b-instruct -n default -o jsonpath='{.status.profiles}' | jq
+```
+
+Step 2: Deploy the NIMService to serve the cached model:
+
+```bash
+helm install nim-llama-service ai-on-eks/inference-charts -f https://raw.githubusercontent.com/awslabs/ai-on-eks-charts/refs/heads/main/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-service.yaml
+```
+
+Wait for the NIMService to be ready:
+
+```bash
+kubectl wait --for=condition=Ready nimservice/meta-llama-3-1-8b-instruct -n nim-llama-helm --timeout=600s
+```
+
+**Troubleshooting:**
+
+```bash
+# Cache not ready - check status and PVC
+kubectl describe nimcache meta-llama-3-1-8b-instruct
+kubectl get pvc
+
+# If no model profiles are downloaded, remove the model filter in the cache values file and redeploy
+
+# Service not starting - check logs and cache reference
+kubectl logs -l app.kubernetes.io/component=meta-llama-3-1-8b-instruct
+kubectl describe nimservice meta-llama-3-1-8b-instruct
+```
+
+**NIM Container vs NIM Operator:**
+
+| Feature | nim-container | nim-operator |
+|---------|---------------|--------------|
+| Deployment | Single Helm install | Two-step: cache then service |
+| Startup Time | Cold start (slower) | Warm start with cached profiles (faster) |
+| Storage | Ephemeral | Persistent (EFS/NFS) |
+| Profile Optimization | Runtime | Pre-cached for specific GPUs |
+| Best For | Quick testing | Production, multiple replicas, faster scaling |
+
 
 ### S3 Model Copy Examples
 

--- a/charts/inference-charts/templates/NOTES.txt
+++ b/charts/inference-charts/templates/NOTES.txt
@@ -26,7 +26,83 @@ The following service is available:
   http://{{ .Release.Name }}-{{ .Values.inference.accelerator }}-ray-vllm:{{ .Values.service.port }}/v1/chat/completions
 {{- end }}
 
-{{- if ne .Values.inference.framework "nim" }}
+{{- if eq .Values.inference.framework "nim-container" }}
+NVIDIA NIM Container Deployment:
+
+Service: {{ .Values.inference.serviceName }}
+Namespace: {{ .Values.inference.serviceNamespace }}
+
+IMPORTANT: NIM deployments take time to become ready:
+- LLM models (like Llama): 10-15 minutes
+- Diffusion models (like Stable Diffusion): 20-30 minutes
+
+Monitor deployment progress:
+  $ kubectl logs -f deployment/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+Check when ready:
+  $ kubectl get deployment {{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+Test the deployment:
+  $ kubectl port-forward svc/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }} 8000:8000
+
+{{- if contains "stable-diffusion" .Values.model }}
+Example curl command to test image generation:
+
+curl -X POST http://localhost:8000/v1/infer \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "A simple coffee shop interior",
+    "mode": "base",
+    "seed": 0,
+    "steps": 10
+  }'
+{{- else }}
+Example curl command to test chat completion:
+
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "{{ .Values.model }}",
+    "messages": [{"role": "user", "content": "What is AI?"}],
+    "max_tokens": 100
+  }'
+{{- end }}
+
+{{- else if eq .Values.inference.framework "nim-operator" }}
+NVIDIA NIM Operator Deployment:
+
+Namespace: {{ .Values.inference.serviceNamespace }}
+Service Name: {{ .Values.inference.serviceName }}
+
+Step 1 - Create the NIMCache to download and cache the model:
+  $ kubectl get nimcache {{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+  Wait for the cache to be ready:
+  $ kubectl wait --for=condition=Ready nimcache/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }} --timeout=600s
+
+Step 2 - Deploy the NIMService that serves the cached model:
+  $ kubectl get nimservice {{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
+
+  Wait for the service to be ready:
+  $ kubectl wait --for=condition=Ready nimservice/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }} --timeout=600s
+
+Check status:
+  $ kubectl get nimcache,nimservice -n {{ .Values.inference.serviceNamespace }}
+
+Once the NIMService is running, you can test the API:
+  $ kubectl port-forward svc/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }} 8000:8000
+
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "{{ .Values.model | default "default" }}",
+    "messages": [{"role": "user", "content": "What is AI?"}],
+    "max_tokens": 100
+  }'
+
+
+{{- else }}
 Example curl command to test the API:
 
 curl -X POST \
@@ -49,29 +125,12 @@ Available API endpoints:
 - /v1/completions - Text completion API
 - /v1/chat/completions - Chat completion API
 - /metrics - Prometheus metrics endpoint
-{{- else }}
-NVIDIA NIM Deployment:
-
-Service: {{ .Values.inference.serviceName }}
-Namespace: {{ .Values.inference.serviceNamespace }}
-
-IMPORTANT: NIM deployments take time to become ready:
-- LLM models (like Llama): 10-15 minutes
-- Diffusion models (like Stable Diffusion): 20-30 minutes
-
-Monitor deployment progress:
-  $ kubectl logs -f deployment/{{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
-
-Check when ready:
-  $ kubectl get deployment {{ .Values.inference.serviceName }} -n {{ .Values.inference.serviceNamespace }}
-
-For detailed API usage and testing examples, see the README under the header NVIDIA NIM Examples
 {{- end }}
 {{- else }}
 No inference service was enabled. Please set both accelerator and framework values:
 
 - inference.accelerator: gpu or neuron
-- inference.framework: vllm, ray-vllm, triton-vllm, diffusers, lws-vllm, aibrix, or nim
+- inference.framework: vllm, ray-vllm, triton-vllm, diffusers, lws-vllm, aibrix, nim-container, or nim-operator
 
 For example:
   $ helm upgrade {{ .Release.Name }} . --set inference.accelerator=gpu --set inference.framework=vllm

--- a/charts/inference-charts/templates/nim-container-deployment.yaml
+++ b/charts/inference-charts/templates/nim-container-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- with .Values.inference.modelServer.deployment.nim.podSecurityContext }}
+      {{- with .Values.inference.modelServer.deployment.nimContainer.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -39,36 +39,36 @@ spec:
         - containerPort: 8000
           name: http
         env:
-        {{- range $key, $value := .Values.inference.modelServer.deployment.nim.env }}
+        {{- range $key, $value := .Values.inference.modelServer.deployment.nimContainer.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
         - name: NGC_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.inference.modelServer.deployment.nim.secrets.ngcApiKey.name }}
-              key: {{ .Values.inference.modelServer.deployment.nim.secrets.ngcApiKey.key }}
+              name: {{ .Values.inference.modelServer.deployment.nimContainer.secrets.ngcApiKey.name }}
+              key: {{ .Values.inference.modelServer.deployment.nimContainer.secrets.ngcApiKey.key }}
         - name: HF_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.inference.modelServer.deployment.nim.secrets.hfToken.name }}
-              key: {{ .Values.inference.modelServer.deployment.nim.secrets.hfToken.key }}
-        {{- with .Values.inference.modelServer.deployment.nim.securityContext }}
+              name: {{ .Values.inference.modelServer.deployment.nimContainer.secrets.hfToken.name }}
+              key: {{ .Values.inference.modelServer.deployment.nimContainer.secrets.hfToken.key }}
+        {{- with .Values.inference.modelServer.deployment.nimContainer.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.inference.modelServer.deployment.resources.gpu | nindent 10 }}
-        {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+        {{- if .Values.inference.modelServer.deployment.nimContainer.shm.enabled }}
         volumeMounts:
         - name: dev-shm
           mountPath: /dev/shm
         {{- end }}
-        {{- with .Values.inference.modelServer.deployment.nim.livenessProbe }}
+        {{- with .Values.inference.modelServer.deployment.nimContainer.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.inference.modelServer.deployment.nim.readinessProbe }}
+        {{- with .Values.inference.modelServer.deployment.nimContainer.readinessProbe }}
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -104,12 +104,12 @@ spec:
                     "app.kubernetes.io/component": "{{$.Values.inference.serviceName}}"
             {{- end }}
       {{- end }}
-      {{- if .Values.inference.modelServer.deployment.nim.shm.enabled }}
+      {{- if .Values.inference.modelServer.deployment.nimContainer.shm.enabled }}
       volumes:
       - name: dev-shm
         emptyDir:
-          medium: {{ .Values.inference.modelServer.deployment.nim.shm.medium }}
-          sizeLimit: {{ .Values.inference.modelServer.deployment.nim.shm.sizeLimit }}
+          medium: {{ .Values.inference.modelServer.deployment.nimContainer.shm.medium }}
+          sizeLimit: {{ .Values.inference.modelServer.deployment.nimContainer.shm.sizeLimit }}
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/inference-charts/templates/nim-operator-cache.yaml
+++ b/charts/inference-charts/templates/nim-operator-cache.yaml
@@ -1,0 +1,73 @@
+{{- if and (.Values.nimCache).enabled (eq .Values.inference.framework "nim-operator") }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ .Values.inference.serviceName }}
+  namespace: {{ .Values.inference.serviceNamespace }}
+  labels:
+    {{- include "inference-charts.labels" . | nindent 4 }}
+    {{- with .Values.nimCache.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  source:
+    ngc:
+      modelPuller: {{ .Values.nimCache.source.ngc.modelPuller }}
+      pullSecret: {{ .Values.nimCache.source.ngc.pullSecret }}
+      authSecret: {{ .Values.nimCache.source.ngc.authSecret }}
+      {{- if .Values.nimCache.source.ngc.model }}
+      model:
+        {{- if .Values.nimCache.source.ngc.model.profiles }}
+        profiles:
+          {{- toYaml .Values.nimCache.source.ngc.model.profiles | nindent 10 }}
+        {{- else }}
+        {{- if .Values.nimCache.source.ngc.model.engine }}
+        engine: {{ .Values.nimCache.source.ngc.model.engine }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.tensorParallelism }}
+        tensorParallelism: {{ .Values.nimCache.source.ngc.model.tensorParallelism | quote }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.buildable }}
+        buildable: {{ .Values.nimCache.source.ngc.model.buildable }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.precision }}
+        precision: {{ .Values.nimCache.source.ngc.model.precision | quote }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.qosProfile }}
+        qosProfile: {{ .Values.nimCache.source.ngc.model.qosProfile | quote }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.gpus }}
+        gpus:
+          {{- toYaml .Values.nimCache.source.ngc.model.gpus | nindent 10 }}
+        {{- end }}
+        {{- if .Values.nimCache.source.ngc.model.lora }}
+        lora: {{ .Values.nimCache.source.ngc.model.lora }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+  {{- if .Values.nimCache.env }}
+  env:
+    {{- toYaml .Values.nimCache.env | nindent 4 }}
+  {{- end }}
+  storage:
+    pvc:
+      create: {{ .Values.nimCache.storage.pvc.create }}
+      {{- if .Values.nimCache.storage.pvc.storageClass }}
+      storageClass: {{ .Values.nimCache.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ .Values.nimCache.storage.pvc.size | quote }}
+      volumeAccessMode: {{ .Values.nimCache.storage.pvc.volumeAccessMode }}
+  {{- if .Values.nimCache.nodeSelector }}
+  nodeSelector:
+    {{- toYaml .Values.nimCache.nodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nimCache.tolerations }}
+  tolerations:
+    {{- toYaml .Values.nimCache.tolerations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.nimCache.resources }}
+  resources:
+    {{- toYaml .Values.nimCache.resources | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/inference-charts/templates/nim-operator-service.yaml
+++ b/charts/inference-charts/templates/nim-operator-service.yaml
@@ -1,0 +1,108 @@
+{{- if and (.Values.nimService).enabled (eq .Values.inference.framework "nim-operator") }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ .Values.inference.serviceName }}
+  namespace: {{ .Values.inference.serviceNamespace }}
+  labels:
+    {{- include "inference-charts.labels" . | nindent 4 }}
+    {{- with .Values.nimService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  image:
+    repository: {{ .Values.nimService.image.repository }}
+    tag: {{ .Values.nimService.image.tag }}
+    pullPolicy: {{ .Values.nimService.image.pullPolicy }}
+    {{- if .Values.imagePullSecrets }}
+    pullSecrets:
+      {{- range .Values.imagePullSecrets }}
+      - {{ .name }}
+      {{- end }}
+    {{- end }}
+
+  {{- if .Values.nimService.authSecret }}
+  authSecret: {{ .Values.nimService.authSecret }}
+  {{- end }}
+
+  {{- if .Values.nimService.storage }}
+  storage:
+    {{- if .Values.nimService.storage.nimCache }}
+    nimCache:
+      name: {{ .Values.nimService.storage.nimCache.name }}
+      {{- if .Values.nimService.storage.nimCache.profile }}
+      profile: {{ .Values.nimService.storage.nimCache.profile }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.nimService.storage.pvc }}
+    pvc:
+      {{- toYaml .Values.nimService.storage.pvc | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .Values.nimService.replicas }}
+  replicas: {{ .Values.nimService.replicas }}
+  {{- end }}
+
+  {{- if .Values.nimService.env }}
+  env:
+    {{- toYaml .Values.nimService.env | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.nimService.resources }}
+  resources:
+    {{- toYaml .Values.nimService.resources | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.nimService.nodeSelector }}
+  nodeSelector:
+    {{- toYaml .Values.nimService.nodeSelector | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.nimService.tolerations }}
+  tolerations:
+    {{- toYaml .Values.nimService.tolerations | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.inference.modelServer.deployment.topologySpreadConstraints.enabled }}
+  topologySpreadConstraints:
+    {{- range .Values.inference.modelServer.deployment.topologySpreadConstraints.constraints }}
+    - maxSkew: {{ .maxSkew }}
+      topologyKey: {{ .topologyKey }}
+      whenUnsatisfiable: {{ .whenUnsatisfiable }}
+      labelSelector:
+        matchLabels:
+          "app.kubernetes.io/component": "{{ $.Values.inference.serviceName }}"
+    {{- end }}
+  {{- end }}
+
+  {{- if and .Values.inference.modelServer.deployment.podAffinity.enabled .Values.inference.modelServer.deployment.podAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+  affinity:
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        {{- range .Values.inference.modelServer.deployment.podAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+        - weight: {{ .weight }}
+          podAffinityTerm:
+            topologyKey: {{ .podAffinityTerm.topologyKey }}
+            labelSelector:
+              matchLabels:
+                "app.kubernetes.io/component": "{{ $.Values.inference.serviceName }}"
+        {{- end }}
+  {{- end }}
+
+  {{- if .Values.nimService.expose }}
+  expose:
+    {{- toYaml .Values.nimService.expose | nindent 4 }}
+  {{- else }}
+  expose:
+    service:
+      type: {{ .Values.service.type }}
+      port: {{ .Values.service.port }}
+  {{- end }}
+
+  {{- if .Values.nimService.metrics }}
+  metrics:
+    {{- toYaml .Values.nimService.metrics | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/inference-charts/values-llama-3-8b-instruct-nim-container.yaml
+++ b/charts/inference-charts/values-llama-3-8b-instruct-nim-container.yaml
@@ -5,7 +5,7 @@
 model: meta/llama3-8b-instruct
 
 inference:
-  serviceName: nim-llama-31-8b
+  serviceName: nim-llama-3-8b
   serviceNamespace: default # Recommended: Move to a dedicated namespace (e.g., 'nim') to ensure service isolation.
   accelerator: gpu
   framework: nim-container
@@ -30,8 +30,8 @@ inference:
             memory: "64Gi"
             nvidia.com/gpu: "1"
 
-      # NIM-specific configuration (inherits from values.yaml nim section)
-      nim:
+      # NIM-specific configuration (inherits from values.yaml nimContainer section)
+      nimContainer:
         # LLM-specific environment variables
         # For full list: https://docs.nvidia.com/nim/large-language-models/latest/configuration.html
         env:

--- a/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-cache.yaml
+++ b/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-cache.yaml
@@ -1,0 +1,48 @@
+# NIMCache configuration for LLaMA 3.1 8B Instruct
+# This values file enables pre-pulling and caching of the model profile
+# to a shared PVC for faster NIMService pod startup times
+# Common NIM operator defaults are in values.yaml under nimCache
+
+model: meta/llama-3.1-8b-instruct
+
+inference:
+  serviceName: meta-llama-3-1-8b-instruct
+  serviceNamespace: default
+  framework: nim-operator
+
+
+nimCache:
+  enabled: true #override from values
+
+  source:
+    ngc:
+      modelPuller: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.3.3
+      model:
+        engine: tensorrt_llm
+        tensorParallelism: "1"
+        lora: false
+        # Uncomment and configure as needed:
+        # precision: "fp8"
+        # qosProfile: "throughput"
+        # gpus:
+        #   - product: "l40s"
+
+  nodeSelector:
+    karpenter.sh/nodepool: g6e-nvidia
+
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret
+
+  # Uncomment the following env section if you are using HF models
+  # env:
+  #   - name: HF_TOKEN
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: hf-token
+  #         key: HF_TOKEN

--- a/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-service.yaml
+++ b/charts/inference-charts/values-llama-31-8b-instruct-nim-operator-service.yaml
@@ -1,0 +1,55 @@
+# NIMService configuration for LLaMA 3.1 8B Instruct
+# This values file deploys the inference service using cached model profiles
+# PREREQUISITE: Deploy NIMCache first using values-llama-31-8b-instruct-nim-operator-cache.yaml
+# Common NIM operator defaults are in values.yaml under nimService
+
+model: meta/llama-3.1-8b-instruct
+
+inference:
+  serviceName: meta-llama-3-1-8b-instruct
+  serviceNamespace: default
+  framework: nim-operator
+
+
+nimService:
+  enabled: true #override from values
+
+  image:
+    repository: nvcr.io/nim/meta/llama-3.1-8b-instruct
+    tag: "1.3.3"
+    pullPolicy: IfNotPresent
+
+  storage:
+    nimCache:
+      name: meta-llama-3-1-8b-instruct
+      profile: ""
+
+  resources:
+    requests:
+      cpu: "4"
+      memory: "16Gi"
+      nvidia.com/gpu: "1"
+    limits:
+      cpu: "8"
+      memory: "48Gi"
+      nvidia.com/gpu: "1"
+
+  nodeSelector:
+    karpenter.sh/nodepool: g6e-nvidia
+
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret
+
+  # Uncomment the following env section if you are using HF models
+  # env:
+  #   - name: HF_TOKEN
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: hf-token
+  #         key: HF_TOKEN

--- a/charts/inference-charts/values-llama-32-1b-instruct-nim-operator-cache.yaml
+++ b/charts/inference-charts/values-llama-32-1b-instruct-nim-operator-cache.yaml
@@ -1,0 +1,47 @@
+# NIMCache configuration for LLaMA 3.2 1B Instruct
+# This values file enables pre-pulling and caching of the model profile
+# to a shared PVC for faster NIMService pod startup times
+# Common NIM operator defaults are in values.yaml under nimCache
+
+model: meta/llama-3.2-1b-instruct
+
+inference:
+  serviceName: meta-llama-3-2-1b-instruct
+  serviceNamespace: default
+  framework: nim-operator
+
+nimCache:
+  enabled: true #override from values
+
+  source:
+    ngc:
+      modelPuller: nvcr.io/nim/meta/llama-3.2-1b-instruct:1.12.0
+      model:
+        engine: tensorrt_llm
+        tensorParallelism: "1"
+        lora: false
+        # Uncomment and configure as needed:
+        # precision: "fp8"
+        # qosProfile: "throughput"
+        # gpus:
+        #   - product: "l40s"
+
+  nodeSelector:
+    karpenter.sh/nodepool: g6e-nvidia
+
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret
+
+  # Uncomment the following env section if you are using HF models
+  # env:
+  #   - name: HF_TOKEN
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: hf-token
+  #         key: HF_TOKEN

--- a/charts/inference-charts/values-llama-32-1b-instruct-nim-operator-service.yaml
+++ b/charts/inference-charts/values-llama-32-1b-instruct-nim-operator-service.yaml
@@ -1,0 +1,54 @@
+# NIMService configuration for LLaMA 3.2 1B Instruct
+# This values file deploys the inference service using cached model profiles
+# PREREQUISITE: Deploy NIMCache first using values-llama-32-1b-instruct-nim-operator-cache.yaml
+# Common NIM operator defaults are in values.yaml under nimService
+
+model: meta/llama-3.2-1b-instruct
+
+inference:
+  serviceName: meta-llama-3-2-1b-instruct
+  serviceNamespace: default
+  framework: nim-operator
+
+nimService:
+  enabled: true #override from values
+
+  image:
+    repository: nvcr.io/nim/meta/llama-3.2-1b-instruct
+    tag: "1.12.0"
+    pullPolicy: IfNotPresent
+
+  storage:
+    nimCache:
+      name: meta-llama-3-2-1b-instruct
+      profile: ""
+
+  resources:
+    requests:
+      cpu: "4"
+      memory: "16Gi"
+      nvidia.com/gpu: "1"
+    limits:
+      cpu: "4"
+      memory: "32Gi"
+      nvidia.com/gpu: "1"
+
+  nodeSelector:
+    karpenter.sh/nodepool: g6e-nvidia
+
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+# Image pull secrets for NGC registry
+imagePullSecrets:
+  - name: ngc-secret
+
+  # Uncomment the following env section if you are using HF models
+  # env:
+  #   - name: HF_TOKEN
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: hf-token
+  #         key: HF_TOKEN

--- a/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim-container.yaml
+++ b/charts/inference-charts/values-stable-diffusion-3.5-large-diffusers-nim-container.yaml
@@ -13,7 +13,7 @@ inference:
   modelServer:
     image:
       repository: nvcr.io/nim/stabilityai/stable-diffusion-3.5-large
-      tag: latest
+      tag: 1.0.1
 
     deployment:
       replicas: 1
@@ -30,8 +30,8 @@ inference:
             memory: "128Gi"
             nvidia.com/gpu: "1"
 
-      # NIM-specific configuration (inherits from values.yaml nim section)
-      nim:
+      # NIM-specific configuration (inherits from values.yaml nimContainer section)
+      nimContainer:
         # Diffusion model-specific environment variables
         # For full list: https://docs.nvidia.com/nim/visual-genai/1.0.0/configuration.html
         env:

--- a/charts/inference-charts/values.yaml
+++ b/charts/inference-charts/values.yaml
@@ -93,9 +93,9 @@ inference:
             aws.amazon.com/neuron: 1
           limits:
             aws.amazon.com/neuron: 1
-      # NIM-specific configuration (NVIDIA Inference Microservices)
+      # NIM Container-specific configuration (NVIDIA Inference Microservices)
       # These are default values that can be overridden in model-specific values files
-      nim:
+      nimContainer:
         # Common NIM environment variables
         env:
           NVIDIA_VISIBLE_DEVICES: "all"
@@ -201,3 +201,27 @@ ingress:
   annotations: {}
   hosts: []
   tls: []
+
+# NIM Operator defaults (framework: nim-operator)
+# Model-specific values files override what differs.
+# Helm deep-merges these with per-model values, so templates always use .Values.nimCache / .Values.nimService.
+
+nimCache:
+  enabled: false
+  source:
+    ngc:
+      pullSecret: ngc-secret
+      authSecret: ngc-api
+  storage:
+    pvc:
+      create: true
+      storageClass: efs-sc-dynamic
+      size: "50Gi"
+      volumeAccessMode: ReadWriteMany
+
+nimService:
+  enabled: false
+  image:
+    pullPolicy: IfNotPresent
+  authSecret: ngc-api
+  replicas: 1


### PR DESCRIPTION
**Summary**
Introduces Helm chart support for deploying models via the NVIDIA NIM Operator (NIMCache + NIMService CRDs), alongside renaming the existing NIM deployment path from `nim` to `nim-container` to clearly distinguish the two approaches.

**What changed**

**New templates:**
`nim-operator-cache.yaml` — NIMCache CRD that pre-pulls and caches model profiles to a shared PVC for faster pod startup
`nim-operator-service.yaml` — NIMService CRD that serves cached models with support for topology spread, pod affinity, and autoscaling

**New values files:**

Model: `meta/llama-3.1-8b-instruct`
`values-llama-31-8b-instruct-nim-operator-cache.yaml` 
`values-llama-31-8b-instruct-nim-operator-service.yaml`

Model: `meta-llama-3-2-1b-instruct`
`values-llama-32-1b-instruct-nim-operator-cache.yaml`
`values-llama-32-1b-instruct-nim-operator-service.yaml`

**Renames (breaking):**

`nim-deployment.yaml` → `nim-container-deployment.yaml`
`values-llama-3-8b-instruct-nim.yaml` → `values-llama-3-8b-instruct-nim-container.yaml`
`values-stable-diffusion-3.5-large-diffusers-nim.yaml` → `values-stable-diffusion-3.5-large-diffusers-nim-container.yaml`
`inference.framework` value `nim` → `nim-container` or `nim-operator`
`inference.modelServer.deployment.nim` → `inference.modelServer.deployment.nimContainer`

**Default values (values.yaml):**

Added `nimCache` and `nimService` top-level defaults for the operator path (both disabled by default)

Default storage uses `efs-sc-dynamic` StorageClass with ReadWriteMany access for shared caching

**NOTES.txt:**

Expanded post-install notes with framework-specific guidance for nim-container, nim-operator, and other frameworks
Updated the supported framework list to include nim-container and nim-operator

**README.md:**

* Split the NIM section into "NIM Container" and "NIM Operator" with separate prerequisites and deployment steps
* Added a comparison table (container vs operator) covering startup time, storage, profile optimization, and recommended use cases
* Updated URLs to point to the correct cluster setup docs
* Deployment flow for NIM Operator

**Breaking changes**
Existing users of the nim framework value and deployment.nim config key will need to update to nim-container / deployment.nimContainer.  


**Testing Steps**

Model: `meta/llama-3.1-8b-instruct`

```bash
#Dry-run template rendering and verify the generated manifests
helm template nim-llama-cache charts/inference-charts \
  -f charts/inference-charts/values-llama-31-8b-instruct-nim-operator-cache.yaml | kubectl apply --dry-run=client -f -

helm template nim-llama-service charts/inference-charts \
  -f charts/inference-charts/values-llama-31-8b-instruct-nim-operator-service.yaml | kubectl apply --dry-run=client -f -

# Deploy the cache, wait for readiness, then deploy the service
helm install nim-llama-cache charts/inference-charts \
  -f charts/inference-charts/values-llama-31-8b-instruct-nim-operator-cache.yaml

kubectl wait --for=condition=Ready nimcache/meta-llama-3-1-8b-instruct -n default --timeout=600s

helm install nim-llama-service charts/inference-charts \
  -f charts/inference-charts/values-llama-31-8b-instruct-nim-operator-service.yaml

kubectl wait --for=condition=Ready nimservice/meta-llama-3-1-8b-instruct -n default --timeout=600s

# Smoke test
kubectl port-forward svc/meta-llama-3-1-8b-instruct 8000:8000 -n default &
curl -s -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"meta/llama-3.1-8b-instruct","messages":[{"role":"user","content":"Hello"}],"max_tokens":50}'

# Cleanup
helm uninstall nim-llama-service
helm uninstall nim-llama-cache
```
Model: `meta-llama-3-2-1b-instruct`

```bash
helm template nim-llama-cache charts/inference-charts \
  -f charts/inference-charts/values-llama-32-1b-instruct-nim-operator-cache.yaml | kubectl apply --dry-run=client -f -
helm template nim-llama-service charts/inference-charts \
  -f charts/inference-charts/values-llama-32-1b-instruct-nim-operator-service.yaml | kubectl apply --dry-run=client -f -

helm install nim-llama-cache charts/inference-charts \
  -f charts/inference-charts/values-llama-32-1b-instruct-nim-operator-cache.yaml
kubectl wait --for=condition=Ready nimcache/meta-llama-3-2-1b-instruct -n default --timeout=600s

helm install nim-llama-service charts/inference-charts \
  -f charts/inference-charts/values-llama-32-1b-instruct-nim-operator-service.yaml
kubectl wait --for=condition=Ready nimservice/meta-llama-3-2-1b-instruct -n default --timeout=600s

kubectl port-forward svc/meta-llama-3-2-1b-instruct 8000:8000 -n default &
curl -s -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"meta/llama-3.2-1b-instruct","messages":[{"role":"user","content":"Hello"}],"max_tokens":50}'

helm uninstall nim-llama-service
helm uninstall nim-llama-cache
```


Testing results:

Model: `meta/llama-3.1-8b-instruct`
NimCache:
<img width="779" height="561" alt="llama31-8b cache" src="https://github.com/user-attachments/assets/88a90b60-a879-4c57-8b08-72fa506844d0" />


NimService:
<img width="797" height="922" alt="llama31-8b" src="https://github.com/user-attachments/assets/fd78c4ea-0b58-4314-ba11-56cd15c76033" />


Model: `meta-llama-3-2-1b-instruct`
NimCache:
<img width="881" height="479" alt="llama31-1b cache" src="https://github.com/user-attachments/assets/359c2feb-5e7b-4cd0-8d44-20f7757d4781" />


NimService:
<img width="816" height="918" alt="llama32-1b" src="https://github.com/user-attachments/assets/5dc3f750-09cc-4c69-bf39-eda8005db415" />

