### PR TITLE
feat: Add Llama 4 Neuron values for Scout and Maverick on Trainium2

### DIFF
--- a/charts/inference-charts/values-llama-4-maverick-17b-vllm-neuron.yaml
+++ b/charts/inference-charts/values-llama-4-maverick-17b-vllm-neuron.yaml
@@ -1,0 +1,42 @@
+model: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+
+modelParameters:
+  dtype: bfloat16
+  maxModelLen: 4096
+  maxNumSeqs: 2
+  maxNumBatchedTokens: 4096
+  tensorParallelSize: 16
+
+inference:
+  serviceName: llama4-maverick-neuron
+  serviceNamespace: default
+  accelerator: neuron
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: 763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-vllm-inference-neuronx
+      tag: "0.11.0-optimum0.4.5-neuronx-py310-sdk2.26.1-ubuntu22.04"
+    env:
+      NEURON_CC_FLAGS: "--model-type transformer"
+      VLLM_NEURON_FRAMEWORK: "optimum"
+    deployment:
+      instanceType: trn2.48xlarge
+      resources:
+        neuron:
+          requests:
+            aws.amazon.com/neuron: "16"
+            memory: 1024Gi
+          limits:
+            aws.amazon.com/neuron: "16"
+            memory: 1024Gi
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        periodSeconds: 30
+        failureThreshold: 240
+
+service:
+  type: ClusterIP
+  port: 8000

--- a/charts/inference-charts/values-llama-4-scout-17b-vllm-neuron.yaml
+++ b/charts/inference-charts/values-llama-4-scout-17b-vllm-neuron.yaml
@@ -1,0 +1,42 @@
+model: meta-llama/Llama-4-Scout-17B-16E-Instruct
+
+modelParameters:
+  dtype: bfloat16
+  maxModelLen: 4096
+  maxNumSeqs: 4
+  maxNumBatchedTokens: 4096
+  tensorParallelSize: 16
+
+inference:
+  serviceName: llama4-scout-neuron
+  serviceNamespace: default
+  accelerator: neuron
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: 763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-vllm-inference-neuronx
+      tag: "0.11.0-optimum0.4.5-neuronx-py310-sdk2.26.1-ubuntu22.04"
+    env:
+      NEURON_CC_FLAGS: "--model-type transformer"
+      VLLM_NEURON_FRAMEWORK: "optimum"
+    deployment:
+      instanceType: trn2.48xlarge
+      resources:
+        neuron:
+          requests:
+            aws.amazon.com/neuron: "16"
+            memory: 384Gi
+          limits:
+            aws.amazon.com/neuron: "16"
+            memory: 384Gi
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        periodSeconds: 30
+        failureThreshold: 180
+
+service:
+  type: ClusterIP
+  port: 8000


### PR DESCRIPTION
Add Helm values files for deploying Llama 4 models on AWS Trainium2 instances using vLLM with optimum-neuron:

- values-llama-4-scout-17b-vllm-neuron.yaml (trn2.48xlarge, 384Gi)
- values-llama-4-maverick-17b-vllm-neuron.yaml (trn2.48xlarge, 1024Gi)

Key configuration:
- AWS Neuron DLC image (optimum-neuron 0.4.5, Neuron SDK 2.26.1)
- tensor-parallel-size 16 (all 16 Trainium chips)
- VLLM_NEURON_FRAMEWORK=optimum for on-the-fly compilation
- BF16 dtype (no quantization needed on Trainium2)
- Verified on trn2.48xlarge with ~20 min total deployment time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.