### PR TITLE
fix: handle boolean modelParameters as CLI flags without values

### DIFF
--- a/charts/inference-charts/Chart.yaml
+++ b/charts/inference-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: inference-charts
 description: A Helm chart for AI on EKS
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "1.0.0"

--- a/charts/inference-charts/templates/_helpers.tpl
+++ b/charts/inference-charts/templates/_helpers.tpl
@@ -69,7 +69,13 @@ app.kubernetes.io/component: {{.Values.inference.serviceName}}
 {{- $args := list -}}
 {{ $tpsize := 1 -}}
 {{- range $key, $value := $modelParameters -}}
-  {{- $args = append $args (printf "--%s %v" ($key | kebabcase) $value) -}}
+  {{- if kindIs "bool" $value -}}
+    {{- if $value -}}
+      {{- $args = append $args (printf "--%s" ($key | kebabcase)) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $args = append $args (printf "--%s %v" ($key | kebabcase) $value) -}}
+  {{- end -}}
 {{- end -}}
 {{- if eq .Values.inference.framework "aibrix" }}
     {{- $args = append $args (printf "--served-model-name %s" .Values.inference.serviceName) }}


### PR DESCRIPTION
## Summary

- Boolean `modelParameters` (like `enablePrefixCaching: true`) are rendered as `--enable-prefix-caching true`, but vLLM boolean flags use argparse `store_true` and reject the `true` argument
- This causes `vllm: error: unrecognized arguments: true` at container startup
- Fix: check `kindIs "bool"` in the `modelParameters` range loop — emit `--flag` for `true`, skip for `false`

## Reproduction

```yaml
modelParameters:
  enablePrefixCaching: true
  gpuMemoryUtilization: 0.9
```

**Before (broken):**
```
vllm serve model --enable-prefix-caching true --gpu-memory-utilization 0.9
# => vllm: error: unrecognized arguments: true
```

**After (fixed):**
```
vllm serve model --enable-prefix-caching --gpu-memory-utilization 0.9
```

## Affected flags

Any boolean modelParameter, including: `enablePrefixCaching`, `enforceEager`, `enableChunkedPrefill`

## Test plan

- [x] `helm template` renders boolean flags without values
- [x] `helm template` renders non-boolean flags with values (unchanged)
- [x] Deployed vLLM with `enablePrefixCaching: true` — container starts successfully