### PR TITLE
feat: add GLM-5.2 and GLM-4.5-Air vLLM values files

### DIFF
--- a/charts/inference-charts/README.md
+++ b/charts/inference-charts/README.md
@@ -219,6 +219,8 @@ The chart includes pre-configured values files for the following models:
 #### Language Models
 
 - **DeepSeek R1 Distill Llama 8B**: `values-deepseek-r1-distill-llama-8b-ray-vllm-gpu.yaml` (Ray-VLLM)
+- **GLM-4.5-Air**: `values-glm-4-5-air-vllm.yaml` (VLLM)
+- **GLM-5.2**: `values-glm-5-2-vllm.yaml` (VLLM)
 - **Llama 3.2 1B**: `values-llama-32-1b-vllm.yaml` (VLLM), `values-llama-32-1b-ray-vllm.yaml` (Ray-VLLM),
   `values-llama-32-1b-ray-vllm-autoscaling.yaml` (Ray-VLLM with autoscaling),
   `values-llama-32-1b-aibrix.yaml` (AIBrix), and `values-llama-32-1b-triton-vllm-gpu.yaml` (Triton-VLLM)

--- a/charts/inference-charts/values-glm-4-5-air-vllm.yaml
+++ b/charts/inference-charts/values-glm-4-5-air-vllm.yaml
@@ -1,0 +1,31 @@
+# GLM-4.5-Air FP8 (~106B MoE, ~12B active; ~130GB weights) fits a single
+# g6e.48xlarge (8x L40S, 384GB) — no P-family capacity required.
+model: zai-org/GLM-4.5-Air-FP8
+
+modelParameters:
+  maxModelLen: 131072
+  tensorParallelSize: 8
+  gpuMemoryUtilization: 0.90
+  enablePrefixCaching: true
+  enableAutoToolChoice: true
+  toolCallParser: glm45
+  reasoningParser: glm45
+
+inference:
+  serviceName: glm-4-5-air-vllm
+  serviceNamespace: default
+  accelerator: gpu
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: public.ecr.aws/deep-learning-containers/vllm
+      tag: 0.10.2-gpu-py312-ec2
+    deployment:
+      resources:
+        gpu:
+          requests:
+            nvidia.com/gpu: 8
+          limits:
+            nvidia.com/gpu: 8
+      instanceType: g6e.48xlarge # Highly recommended to add the instance type

--- a/charts/inference-charts/values-glm-5-2-vllm.yaml
+++ b/charts/inference-charts/values-glm-5-2-vllm.yaml
@@ -1,0 +1,31 @@
+# GLM-5.2 FP8 (~700GB weights) fits a single p5en.48xlarge (8x H200, 1128GB HBM).
+# Pair with values-s3-copy-glm-5-2.yaml to stage weights in S3 before first deploy.
+model: zai-org/GLM-5.2-FP8
+
+modelParameters:
+  maxModelLen: 131072
+  tensorParallelSize: 8
+  gpuMemoryUtilization: 0.92
+  enablePrefixCaching: true
+  enableAutoToolChoice: true
+  toolCallParser: glm47
+  reasoningParser: glm47
+
+inference:
+  serviceName: glm-5-2-vllm
+  serviceNamespace: default
+  accelerator: gpu
+  framework: vllm
+
+  modelServer:
+    image:
+      repository: public.ecr.aws/deep-learning-containers/vllm
+      tag: 0.10.2-gpu-py312-ec2
+    deployment:
+      resources:
+        gpu:
+          requests:
+            nvidia.com/gpu: 8
+          limits:
+            nvidia.com/gpu: 8
+      instanceType: p5en.48xlarge # Highly recommended to add the instance type


### PR DESCRIPTION
## What

Adds pre-configured single-node vLLM values files for the zai-org GLM family, plus README entries under Supported Models:

- `values-glm-5-2-vllm.yaml` — GLM-5.2-FP8 (~700 GB weights) on p5en.48xlarge (8x H200, 1128 GB HBM), TP=8. Pairs with the existing `values-s3-copy-glm-5-2.yaml` for S3 weight staging.
- `values-glm-4-5-air-vllm.yaml` — GLM-4.5-Air-FP8 (~106B MoE, ~12B active, ~130 GB weights) on g6e.48xlarge (8x L40S, 384 GB), TP=8 — no P-family capacity required.

Both enable `--enable-auto-tool-choice`, tool-call/reasoning parsers (`glm47` for 5.2, `glm45` for 4.5-Air), and prefix caching, so the endpoints work out of the box for agentic/tool-calling workloads.

## Why

The repo already ships the S3 model-copy values for GLM-5.2 (#15) but no serving values file for it. These fill that gap following the pattern of the existing Llama 4 / Qwen 3 Coder values files.

## Validation

`helm lint` passes for both. Rendered with `helm template` against chart v0.2.4:

```
vllm serve zai-org/GLM-5.2-FP8 --enable-auto-tool-choice --enable-prefix-caching --gpu-memory-utilization 0.92 --max-model-len 131072 --reasoning-parser glm47 --tensor-parallel-size 8 --tool-call-parser glm47

vllm serve zai-org/GLM-4.5-Air-FP8 --enable-auto-tool-choice --enable-prefix-caching --gpu-memory-utilization 0.9 --max-model-len 131072 --reasoning-parser glm45 --tensor-parallel-size 8 --tool-call-parser glm45
```

`nodeSelector: node.kubernetes.io/instance-type` pins render correctly for both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
